### PR TITLE
Use public attribute to determine post type cacheability

### DIFF
--- a/src/Tags/CoreTags.php
+++ b/src/Tags/CoreTags.php
@@ -320,7 +320,7 @@ class CoreTags
      */
     public static function getCacheablePostTypes(): array
     {
-        return \get_post_types(['exclude_from_search' => false]);
+        return \get_post_types(['public' => true]);
     }
 
     /**


### PR DESCRIPTION
Right now, in order for post types to be cacheable, they must be visible in search. Modifying the conditional for cacheable post types from `'exclude_from_search' => false` to `'public' => true` allows us to cache post types which display publicly but should not be visible in search.

My use case: I'm using the [Popup Maker](https://wordpress.org/plugins/popup-maker/) plugin to display popups on various pages. This post type is public but `exclude_from_search` is set to false, since users shouldn't be able to find popups while searching.