### PR TITLE
Defer Polylang action binding to pll_init

### DIFF
--- a/src/Actions/Polylang.php
+++ b/src/Actions/Polylang.php
@@ -14,10 +14,15 @@ class Polylang implements Action
 
     public function bind(): void
     {
-        if (! function_exists('pll_current_language')) {
-            return;
+        if (did_action('pll_init')) {
+            $this->init();
+        } else {
+            \add_action('pll_init', [$this, 'init']);
         }
+    }
 
+    public function init(): void
+    {
         \add_filter(CacheTags::FILTER_TAGS, [$this, 'filterArchiveTags'], 5);
         \add_action('transition_post_status', [$this, 'onPostStatusTransition'], 9, 3);
         \add_action('template_redirect', [$this, 'addLanguageTag']);


### PR DESCRIPTION
## Summary

Polylang functions (`pll_current_language`, `pll_is_translated_post_type`, etc.) are not available when the Polylang action's `bind()` is called during Acorn bootstrap. The `function_exists('pll_current_language')` check would fail and the action would silently skip all hook registration.

This defers hook registration to the `pll_init` action, with a `did_action('pll_init')` check for cases where Polylang has already initialized by the time the action is bound.

## Test plan

- [ ] Verify archive tags include language suffix on frontend (e.g. `archive:alert:sv`)
- [ ] Verify `lang:sv` tag appears in cache tags on Swedish pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)