### PR TITLE
Create cache tags table for newly added multisite subsites

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -3,18 +3,22 @@
 namespace Genero\Sage\CacheTags;
 
 use Genero\Sage\CacheTags\Actions\Core;
+use Genero\Sage\CacheTags\Concerns\CreatesDatabaseTable;
 use Genero\Sage\CacheTags\Contracts\Action;
 use Genero\Sage\CacheTags\Contracts\Invalidator;
 use Genero\Sage\CacheTags\Contracts\Store;
 use Genero\Sage\CacheTags\Stores\WordpressDbStore;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_Site;
 
 /**
  * Bootstrap CacheTags for standalone WordPress usage (without Acorn).
  */
 class Bootstrap
 {
+    use CreatesDatabaseTable;
+
     protected bool $debug;
 
     protected ?CacheTags $cacheTags = null;
@@ -134,6 +138,12 @@ class Bootstrap
         // Register WP-CLI commands if available
         $this->registerWpCliCommands();
 
+        // Ensure the cache tags table is created for newly added multisite subsites.
+        // The activation hook only provisions sites existing at activation time.
+        if (is_multisite()) {
+            add_action('wp_initialize_site', [$this, 'createTableForNewSite'], 100);
+        }
+
         // Set up WordPress hooks
         if (! $this->disable) {
             add_action('wp_footer', [$this, 'saveCacheTags']);
@@ -181,6 +191,20 @@ class Bootstrap
 
         foreach ($actions as $action) {
             $this->cacheTags->bindAction($action);
+        }
+    }
+
+    /**
+     * Create the cache tags table for a newly initialized multisite subsite.
+     */
+    public function createTableForNewSite(WP_Site $newSite): void
+    {
+        switch_to_blog((int) $newSite->blog_id);
+
+        try {
+            $this->createTable();
+        } finally {
+            restore_current_blog();
         }
     }
 


### PR DESCRIPTION
## Problem

The `cache_tags` table was only created from `register_activation_hook` (`sage-cachetags.php`), which fires **once** at plugin activation and loops over the sites that exist at that moment. When a new subsite is added to a multisite network later, that hook never re-runs, so the new site's table is never created — causing failures when cache tags are saved/purged for that site.

## Fix

In `src/Bootstrap.php` (the single entry point both the standalone bootstrap and the Acorn `CacheTagsServiceProvider` flow through):

- Pull in the existing `CreatesDatabaseTable` trait.
- Register a `wp_initialize_site` listener (only on multisite) — the hook WordPress fires when a new subsite is provisioned. Priority `100` ensures it runs after core finishes installing the new site's tables (core's initializer runs at priority 10).
- Add `createTableForNewSite()`, which switches into the new blog's context, creates the table, and restores the original blog in a `finally`.

`createTable()` uses `CREATE TABLE IF NOT EXISTS`, so this is idempotent and safe. Existing sites are unaffected.

## Note

This provisions tables for new sites going forward. Subsites already created while the bug was present can be backfilled by running the existing `wp cachetags database` command, which loops over all sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)