### PR TITLE
Fix PHP warnings from production logs

### DIFF
--- a/src/Actions/Core.php
+++ b/src/Actions/Core.php
@@ -135,7 +135,8 @@ class Core implements Action
                 break;
             case 'core/post-terms':
                 if (! empty($attributes['term'])) {
-                    $tags[] = CoreTags::terms(get_the_terms($instance->context['postId'], $attributes['term']));
+                    $postId = $instance->context['postId'] ?? get_the_ID();
+                    $tags[] = CoreTags::terms(get_the_terms($postId, $attributes['term']));
                 }
                 break;
         }

--- a/src/Actions/DebugComment.php
+++ b/src/Actions/DebugComment.php
@@ -30,9 +30,17 @@ class DebugComment implements Action
                 switch ($entity) {
                     case 'menu':
                     case 'term':
-                        return sprintf('[%s] %s (%s)', $tag, get_term($id)->name, get_term($id)->taxonomy);
+                        $term = get_term($id);
+
+                        return $term instanceof \WP_Term
+                            ? sprintf('[%s] %s (%s)', $tag, $term->name, $term->taxonomy)
+                            : sprintf('[%s]', $tag);
                     case 'comment':
-                        return sprintf('[%s] %s', $tag, get_comment($id)->comment_author);
+                        $comment = get_comment($id);
+
+                        return $comment instanceof \WP_Comment
+                            ? sprintf('[%s] %s', $tag, $comment->comment_author)
+                            : sprintf('[%s]', $tag);
                     case 'post':
                         return sprintf('[%s] %s (%s)', $tag, get_post($id)?->post_title ?: $id, get_post_type($id));
                     default:

--- a/src/Stores/WordpressDbStore.php
+++ b/src/Stores/WordpressDbStore.php
@@ -2,21 +2,10 @@
 
 namespace Genero\Sage\CacheTags\Stores;
 
-use Genero\Sage\CacheTags\Concerns\CreatesDatabaseTable;
 use Genero\Sage\CacheTags\Contracts\Store;
 
 class WordpressDbStore implements Store
 {
-    use CreatesDatabaseTable;
-
-    /**
-     * Cache of whether the cache tags table exists, keyed by table name so it
-     * stays correct across multisite blog switches within a request.
-     *
-     * @var array<string, bool>
-     */
-    protected array $tableExists = [];
-
     /**
      * @param  string[]  $tags
      */
@@ -24,10 +13,6 @@ class WordpressDbStore implements Store
     {
         if (empty($tags)) {
             return true;
-        }
-
-        if (! $this->ensureTable()) {
-            return false;
         }
 
         global $wpdb;
@@ -56,10 +41,6 @@ class WordpressDbStore implements Store
             return [];
         }
 
-        if (! $this->ensureTable()) {
-            return [];
-        }
-
         global $wpdb;
         $placeholders = implode(',', array_fill(0, count($tags), '%s'));
 
@@ -77,15 +58,12 @@ class WordpressDbStore implements Store
      */
     public function clear(array $urls, array $tags): bool
     {
+        global $wpdb;
+
         if (empty($urls)) {
             return true;
         }
 
-        if (! $this->ensureTable()) {
-            return false;
-        }
-
-        global $wpdb;
         $placeholders = implode(',', array_fill(0, count($urls), '%s'));
 
         $count = $wpdb->query($wpdb->prepare("
@@ -98,52 +76,10 @@ class WordpressDbStore implements Store
 
     public function flush(): bool
     {
-        if (! $this->ensureTable()) {
-            return false;
-        }
-
         global $wpdb;
 
         return $wpdb->query("
             TRUNCATE `{$wpdb->prefix}cache_tags`
         ");
-    }
-
-    /**
-     * Ensure the cache tags table exists for the current blog before querying
-     * it. Without this guard a missing table (eg a multisite blog where the
-     * table was never installed) floods the log with "table doesn't exist"
-     * query errors on every request. When missing, attempt to (re)create it
-     * once, then fail gracefully if it still cannot be created.
-     */
-    protected function ensureTable(): bool
-    {
-        global $wpdb;
-        $table = "{$wpdb->prefix}cache_tags";
-
-        if (isset($this->tableExists[$table])) {
-            return $this->tableExists[$table];
-        }
-
-        if ($this->tableExistsInDb($table)) {
-            return $this->tableExists[$table] = true;
-        }
-
-        $this->createTable();
-
-        return $this->tableExists[$table] = $this->tableExistsInDb($table);
-    }
-
-    /**
-     * Check whether a table exists without producing a query error if it does
-     * not (SHOW TABLES LIKE returns an empty result for missing tables).
-     */
-    protected function tableExistsInDb(string $table): bool
-    {
-        global $wpdb;
-
-        return $wpdb->get_var(
-            $wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table))
-        ) === $table;
     }
 }

--- a/src/Stores/WordpressDbStore.php
+++ b/src/Stores/WordpressDbStore.php
@@ -2,10 +2,21 @@
 
 namespace Genero\Sage\CacheTags\Stores;
 
+use Genero\Sage\CacheTags\Concerns\CreatesDatabaseTable;
 use Genero\Sage\CacheTags\Contracts\Store;
 
 class WordpressDbStore implements Store
 {
+    use CreatesDatabaseTable;
+
+    /**
+     * Cache of whether the cache tags table exists, keyed by table name so it
+     * stays correct across multisite blog switches within a request.
+     *
+     * @var array<string, bool>
+     */
+    protected array $tableExists = [];
+
     /**
      * @param  string[]  $tags
      */
@@ -13,6 +24,10 @@ class WordpressDbStore implements Store
     {
         if (empty($tags)) {
             return true;
+        }
+
+        if (! $this->ensureTable()) {
+            return false;
         }
 
         global $wpdb;
@@ -41,6 +56,10 @@ class WordpressDbStore implements Store
             return [];
         }
 
+        if (! $this->ensureTable()) {
+            return [];
+        }
+
         global $wpdb;
         $placeholders = implode(',', array_fill(0, count($tags), '%s'));
 
@@ -58,12 +77,15 @@ class WordpressDbStore implements Store
      */
     public function clear(array $urls, array $tags): bool
     {
-        global $wpdb;
-
         if (empty($urls)) {
             return true;
         }
 
+        if (! $this->ensureTable()) {
+            return false;
+        }
+
+        global $wpdb;
         $placeholders = implode(',', array_fill(0, count($urls), '%s'));
 
         $count = $wpdb->query($wpdb->prepare("
@@ -76,10 +98,52 @@ class WordpressDbStore implements Store
 
     public function flush(): bool
     {
+        if (! $this->ensureTable()) {
+            return false;
+        }
+
         global $wpdb;
 
         return $wpdb->query("
             TRUNCATE `{$wpdb->prefix}cache_tags`
         ");
+    }
+
+    /**
+     * Ensure the cache tags table exists for the current blog before querying
+     * it. Without this guard a missing table (eg a multisite blog where the
+     * table was never installed) floods the log with "table doesn't exist"
+     * query errors on every request. When missing, attempt to (re)create it
+     * once, then fail gracefully if it still cannot be created.
+     */
+    protected function ensureTable(): bool
+    {
+        global $wpdb;
+        $table = "{$wpdb->prefix}cache_tags";
+
+        if (isset($this->tableExists[$table])) {
+            return $this->tableExists[$table];
+        }
+
+        if ($this->tableExistsInDb($table)) {
+            return $this->tableExists[$table] = true;
+        }
+
+        $this->createTable();
+
+        return $this->tableExists[$table] = $this->tableExistsInDb($table);
+    }
+
+    /**
+     * Check whether a table exists without producing a query error if it does
+     * not (SHOW TABLES LIKE returns an empty result for missing tables).
+     */
+    protected function tableExistsInDb(string $table): bool
+    {
+        global $wpdb;
+
+        return $wpdb->get_var(
+            $wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table))
+        ) === $table;
     }
 }


### PR DESCRIPTION
Fixes two PHP \"read property on null\" / \"undefined array key\" warnings from production logs.

## Fixes
1. **`src/Actions/DebugComment.php`** — guarded null `get_term()`/`get_comment()` dereferences in `printCacheTagsDebug()` (deleted term/comment fall back to printing the raw tag). Addresses the `post_title`-class "read property on null" warning seen on skandwebshop.
2. **`src/Actions/Core.php`** — the `core/post-terms` block branch read `$instance->context['postId']` unguarded while all siblings guard it; now `?? get_the_ID()`. Addresses `Undefined array key "postId"` on kaskipuu.

## Out of scope (removed)
The earlier `ensureTable()` guard in `WordpressDbStore.php` (for spfpension's missing `wp_6_cache_tags` table) has been **reverted** — per-query guards were the wrong approach. The missing-table flood will be handled separately (proper table creation across all multisite blogs).

`php -l` clean; `composer lint` (Pint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)