### PR TITLE
Purge symmetry fixes + test coverage for existing code

### DIFF
--- a/src/Actions/Core.php
+++ b/src/Actions/Core.php
@@ -21,16 +21,26 @@ class Core implements Action
 
         // Clear caches
         \add_action('transition_post_status', [$this, 'onPostStatusTransition'], 10, 3);
+        \add_action('before_delete_post', [$this, 'onPostDelete']);
         \add_action('transition_comment_status', [$this, 'onCommentStatusTransition'], 10, 3);
         \add_action('comment_post', [$this, 'onCommentPost'], 10, 3);
+        \add_action('edit_comment', [$this, 'onCommentEdit']);
+        \add_action('deleted_comment', [$this, 'onCommentDelete'], 10, 2);
         \add_action('saved_term', [$this, 'onTermSave'], 10, 4);
+        \add_action('delete_term', [$this, 'onTermDelete'], 10, 3);
         \add_action('set_object_terms', [$this, 'onTermSet'], 10, 4);
         \add_action('updated_post_meta', [$this, 'onPostMetaUpdate'], 10, 3);
+        \add_action('added_post_meta', [$this, 'onPostMetaUpdate'], 10, 3);
+        \add_action('deleted_post_meta', [$this, 'onPostMetaUpdate'], 10, 3);
+        \add_action('updated_term_meta', [$this, 'onTermMetaUpdate'], 10, 3);
+        \add_action('added_term_meta', [$this, 'onTermMetaUpdate'], 10, 3);
         \add_action('edit_attachment', [$this, 'onAttachmentEdit']);
         \add_action('wp_update_nav_menu', [$this, 'onMenuUpdate']);
+        \add_action('wp_update_nav_menu_item', [$this, 'onMenuUpdate']);
         \add_action('delete_user', [$this, 'onUserDelete'], 10, 3);
         \add_action('profile_update', [$this, 'onUserUpdate']);
         \add_action('user_register', [$this, 'onUserCreate']);
+        \add_action('set_user_role', [$this, 'onUserRoleChange'], 10, 3);
     }
 
     /**
@@ -186,6 +196,33 @@ class Core implements Action
     }
 
     /**
+     * When a comment's content is edited, clear it and its post.
+     */
+    public function onCommentEdit(int $commentId): void
+    {
+        $comment = get_comment($commentId);
+        if (! $comment instanceof WP_Comment) {
+            return;
+        }
+
+        $this->cacheTags->clear([
+            ...CoreTags::comments($commentId),
+            ...CoreTags::posts((int) $comment->comment_post_ID),
+        ]);
+    }
+
+    /**
+     * When a comment is permanently deleted, clear it and its post.
+     */
+    public function onCommentDelete(int $commentId, WP_Comment $comment): void
+    {
+        $this->cacheTags->clear([
+            ...CoreTags::comments($commentId),
+            ...CoreTags::posts((int) $comment->comment_post_ID),
+        ]);
+    }
+
+    /**
      * This hook is misleading but it runs for scheduled posts, editing a
      * published post as well as manually publishing/unpublishing a post.
      */
@@ -219,6 +256,30 @@ class Core implements Action
         }
 
         $this->cacheTags->clear($cacheTags);
+    }
+
+    /**
+     * On permanent deletion (which skips the trash transition, e.g. for
+     * attachments or EMPTY_TRASH), clear the post and the listings it was in.
+     */
+    public function onPostDelete(int $postId): void
+    {
+        $post = get_post($postId);
+        if (! $post || ! CoreTags::isCacheablePostType($post->post_type)) {
+            return;
+        }
+
+        $taxonomies = array_intersect(
+            CoreTags::getCacheableTaxonomies(),
+            get_post_taxonomies($post)
+        );
+
+        $this->cacheTags->clear([
+            ...CoreTags::posts($post->ID),
+            ...CoreTags::anyArchive($post->post_type),
+            ...CoreTags::archive($post->post_type),
+            ...CoreTags::taxonomy(array_values($taxonomies)),
+        ]);
     }
 
     /**
@@ -261,9 +322,12 @@ class Core implements Action
     }
 
     /**
-     * Whenever a post meta is updated, clear the cache of the post.
+     * Whenever a post meta is added, updated or deleted, clear the post.
+     *
+     * The first argument is a meta id for added/updated_post_meta but an array
+     * of ids for deleted_post_meta; it is unused either way.
      */
-    public function onPostMetaUpdate(int $metaId, int $objectId, string $metaKey): void
+    public function onPostMetaUpdate($metaId, int $objectId, string $metaKey): void
     {
         if (! CoreTags::isCacheablePostType($objectId)) {
             return;
@@ -308,6 +372,39 @@ class Core implements Action
     }
 
     /**
+     * When a term is deleted, clear it and its taxonomy listings.
+     */
+    public function onTermDelete(int $term, int $termTaxonomyId, string $taxonomy): void
+    {
+        if (! CoreTags::isCacheableTaxonomy($taxonomy)) {
+            return;
+        }
+
+        $this->cacheTags->clear([
+            ...CoreTags::terms($term),
+            ...CoreTags::termPages($term),
+            ...CoreTags::taxonomy($taxonomy),
+            ...CoreTags::anyTerm($taxonomy),
+        ]);
+    }
+
+    /**
+     * When term meta is added or updated, clear the term.
+     */
+    public function onTermMetaUpdate($metaId, int $termId, string $metaKey): void
+    {
+        $term = get_term($termId);
+        if (! $term instanceof \WP_Term || ! CoreTags::isCacheableTaxonomy($term->taxonomy)) {
+            return;
+        }
+
+        $this->cacheTags->clear([
+            ...CoreTags::terms($termId),
+            ...CoreTags::termPages($termId),
+        ]);
+    }
+
+    /**
      * When a menu is updated, clear caches using it.
      */
     public function onMenuUpdate(int $menuId): void
@@ -338,6 +435,22 @@ class Core implements Action
         $this->cacheTags->clear([
             ...CoreTags::users($userId),
             ...CoreTags::anyUser(get_userdata($userId)->roles),
+        ]);
+    }
+
+    /**
+     * When a user's role changes (incl. programmatically via set_user_role,
+     * which doesn't fire profile_update), clear the user and both the old and
+     * new role listings.
+     *
+     * @param  string[]  $oldRoles
+     */
+    public function onUserRoleChange(int $userId, string $role, array $oldRoles): void
+    {
+        $this->cacheTags->clear([
+            ...CoreTags::users($userId),
+            ...CoreTags::anyUser($role),
+            ...CoreTags::anyUser($oldRoles),
         ]);
     }
 }

--- a/tests/RestTestCase.php
+++ b/tests/RestTestCase.php
@@ -55,6 +55,19 @@ abstract class RestTestCase extends WP_UnitTestCase
     }
 
     /**
+     * Tags queued for clearing on the singleton (via CacheTags::clear()).
+     *
+     * @return string[]
+     */
+    protected function queuedPurgeTags(): array
+    {
+        $prop = (new ReflectionObject($this->cacheTags))->getProperty('purgeTags');
+        $prop->setAccessible(true);
+
+        return $prop->getValue($this->cacheTags);
+    }
+
+    /**
      * Cache tags emitted on a REST response by the HttpHeader action.
      *
      * @return string[]

--- a/tests/integration/test-clear-events.php
+++ b/tests/integration/test-clear-events.php
@@ -1,0 +1,116 @@
+<?php
+
+use Genero\Sage\CacheTags\Tests\RestTestCase;
+
+/**
+ * Data-change events queue the right tags for clearing (Core action).
+ *
+ * @covers \Genero\Sage\CacheTags\Actions\Core
+ */
+class TestClearEvents extends RestTestCase
+{
+    public function test_deleting_a_term_clears_its_tags(): void
+    {
+        $termId = self::factory()->category->create();
+        $this->resetCacheTags();
+
+        wp_delete_term($termId, 'category');
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("term:{$termId}", $tags);
+        $this->assertContains("term:{$termId}:full", $tags);
+        $this->assertContains('taxonomy:category', $tags);
+        $this->assertContains('taxonomy:category:any', $tags);
+    }
+
+    public function test_editing_a_comment_clears_it_and_its_post(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $commentId = self::factory()->comment->create(['comment_post_ID' => $postId]);
+        $this->resetCacheTags();
+
+        wp_update_comment(['comment_ID' => $commentId, 'comment_content' => 'Edited']);
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("comment:{$commentId}", $tags);
+        $this->assertContains("post:{$postId}", $tags);
+    }
+
+    public function test_deleting_a_comment_clears_it_and_its_post(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $commentId = self::factory()->comment->create(['comment_post_ID' => $postId]);
+        $this->resetCacheTags();
+
+        wp_delete_comment($commentId, true);
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("comment:{$commentId}", $tags);
+        $this->assertContains("post:{$postId}", $tags);
+    }
+
+    public function test_permanently_deleting_a_post_clears_it_and_its_listings(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $this->resetCacheTags();
+
+        wp_delete_post($postId, true);
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("post:{$postId}", $tags);
+        $this->assertContains('archive:post', $tags);
+        $this->assertContains('archive:post:any', $tags);
+    }
+
+    public function test_changing_a_user_role_clears_user_and_both_roles(): void
+    {
+        $userId = self::factory()->user->create(['role' => 'editor']);
+        $this->resetCacheTags();
+
+        (new WP_User($userId))->set_role('author');
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("user:{$userId}", $tags);
+        $this->assertContains('role:author', $tags, 'new role cleared');
+        $this->assertContains('role:editor', $tags, 'old role cleared');
+    }
+
+    public function test_adding_and_deleting_post_meta_clears_the_post(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+
+        $this->resetCacheTags();
+        add_post_meta($postId, 'subtitle', 'Hello');
+        $this->assertContains("post:{$postId}", $this->queuedPurgeTags(), 'added_post_meta');
+
+        $this->resetCacheTags();
+        delete_post_meta($postId, 'subtitle');
+        $this->assertContains("post:{$postId}", $this->queuedPurgeTags(), 'deleted_post_meta');
+    }
+
+    public function test_updating_term_meta_clears_the_term(): void
+    {
+        $termId = self::factory()->category->create();
+        $this->resetCacheTags();
+
+        update_term_meta($termId, 'colour', 'red');
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("term:{$termId}", $tags);
+        $this->assertContains("term:{$termId}:full", $tags);
+    }
+
+    public function test_updating_a_nav_menu_item_clears_the_menu(): void
+    {
+        $menuId = wp_create_nav_menu('Primary');
+        $this->resetCacheTags();
+
+        wp_update_nav_menu_item($menuId, 0, [
+            'menu-item-title' => 'Home',
+            'menu-item-url' => home_url('/'),
+            'menu-item-status' => 'publish',
+        ]);
+
+        $this->assertContains("menu:{$menuId}", $this->queuedPurgeTags());
+    }
+}

--- a/tests/integration/test-deferred-clear-store.php
+++ b/tests/integration/test-deferred-clear-store.php
@@ -1,0 +1,48 @@
+<?php
+
+use Genero\Sage\CacheTags\Stores\DeferredClearStore;
+use Genero\Sage\CacheTags\Stores\WordpressDbStore;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Stores\DeferredClearStore
+ */
+class TestDeferredClearStore extends WP_UnitTestCase
+{
+    public function test_clear_defers_to_a_scheduled_cron_instead_of_clearing_now(): void
+    {
+        $inner = new WordpressDbStore;
+        $inner->save(['post:1'], '/a/');
+        $store = new DeferredClearStore($inner, 60);
+
+        $store->clear(['/a/'], ['post:1']);
+
+        // Not cleared yet — deferred.
+        $this->assertSame(['/a/'], $inner->get(['post:1']));
+        $this->assertNotFalse(wp_next_scheduled(DeferredClearStore::CRON_HOOK));
+
+        $pending = get_transient(DeferredClearStore::TRANSIENT_KEY);
+        $this->assertSame(['/a/'], $pending['urls']);
+        $this->assertSame(['post:1'], $pending['tags']);
+    }
+
+    public function test_processing_pending_clear_delegates_to_the_inner_store(): void
+    {
+        $inner = new WordpressDbStore;
+        $inner->save(['post:1'], '/a/');
+        $store = new DeferredClearStore($inner, 60);
+
+        $store->clear(['/a/'], ['post:1']);
+        $store->processPendingClear();
+
+        $this->assertSame([], $inner->get(['post:1']));
+        $this->assertFalse(get_transient(DeferredClearStore::TRANSIENT_KEY));
+    }
+
+    public function test_save_and_get_pass_through(): void
+    {
+        $store = new DeferredClearStore(new WordpressDbStore, 60);
+        $store->save(['post:2'], '/b/');
+
+        $this->assertSame(['/b/'], $store->get(['post:2']));
+    }
+}

--- a/tests/integration/test-invalidators.php
+++ b/tests/integration/test-invalidators.php
@@ -1,0 +1,80 @@
+<?php
+
+use Genero\Sage\CacheTags\Invalidators\SiteGroundCacheInvalidator;
+use Genero\Sage\CacheTags\Invalidators\SuperCacheInvalidator;
+
+// Recording stubs for the host-cache provider functions, which the invalidators
+// call directly (the real plugins aren't present in the test environment).
+if (! function_exists('sg_cachepress_purge_cache')) {
+    function sg_cachepress_purge_cache($url = false)
+    {
+        $GLOBALS['__sg_calls'][] = $url;
+
+        return true;
+    }
+}
+if (! function_exists('wpsc_delete_url_cache')) {
+    function wpsc_delete_url_cache($url)
+    {
+        $GLOBALS['__wpsc_url_calls'][] = $url;
+
+        return true;
+    }
+}
+if (! function_exists('wpsc_delete_files')) {
+    function wpsc_delete_files($dir)
+    {
+        $GLOBALS['__wpsc_flush'] = true;
+
+        return true;
+    }
+}
+if (! function_exists('get_supercache_dir')) {
+    function get_supercache_dir()
+    {
+        return '/tmp/supercache';
+    }
+}
+
+/**
+ * @covers \Genero\Sage\CacheTags\Invalidators\SiteGroundCacheInvalidator
+ * @covers \Genero\Sage\CacheTags\Invalidators\SuperCacheInvalidator
+ */
+class TestInvalidators extends WP_UnitTestCase
+{
+    public function set_up(): void
+    {
+        parent::set_up();
+        $GLOBALS['__sg_calls'] = [];
+        $GLOBALS['__wpsc_url_calls'] = [];
+        $GLOBALS['__wpsc_flush'] = false;
+    }
+
+    public function test_siteground_purges_each_url_under_the_threshold(): void
+    {
+        (new SiteGroundCacheInvalidator)->clear(['/a/', '/b/'], ['post:1']);
+
+        $this->assertSame(['/a/', '/b/'], $GLOBALS['__sg_calls']);
+    }
+
+    public function test_siteground_bulk_flushes_over_the_threshold(): void
+    {
+        add_filter('cachetags/siteground-bulk-purge-threshold', fn () => 1);
+
+        (new SiteGroundCacheInvalidator)->clear(['/a/', '/b/'], ['post:1']);
+
+        // A single flush call (no url argument) rather than per-url purges.
+        $this->assertSame([false], $GLOBALS['__sg_calls']);
+    }
+
+    public function test_supercache_purges_each_url_and_flushes(): void
+    {
+        $invalidator = new SuperCacheInvalidator;
+
+        $this->assertTrue($invalidator->clear(['/a/', '/b/'], ['post:1']));
+        $this->assertSame(['/a/', '/b/'], $GLOBALS['__wpsc_url_calls']);
+
+        $this->assertTrue($invalidator->flush());
+        $this->assertTrue($GLOBALS['__wpsc_flush']);
+    }
+}

--- a/tests/integration/test-nonce-cron.php
+++ b/tests/integration/test-nonce-cron.php
@@ -1,0 +1,35 @@
+<?php
+
+use Genero\Sage\CacheTags\NonceCron;
+
+/**
+ * @covers \Genero\Sage\CacheTags\NonceCron
+ */
+class TestNonceCron extends WP_UnitTestCase
+{
+    public function tear_down(): void
+    {
+        NonceCron::unschedule();
+        parent::tear_down();
+    }
+
+    public function test_schedule_registers_a_recurring_event_once(): void
+    {
+        NonceCron::schedule();
+        $first = wp_next_scheduled(NonceCron::HOOK);
+
+        $this->assertNotFalse($first);
+        $this->assertSame('twicedaily', wp_get_schedule(NonceCron::HOOK));
+
+        NonceCron::schedule();
+        $this->assertSame($first, wp_next_scheduled(NonceCron::HOOK), 'does not double-schedule');
+    }
+
+    public function test_unschedule_clears_the_event(): void
+    {
+        NonceCron::schedule();
+        NonceCron::unschedule();
+
+        $this->assertFalse(wp_next_scheduled(NonceCron::HOOK));
+    }
+}

--- a/tests/integration/test-store.php
+++ b/tests/integration/test-store.php
@@ -1,0 +1,70 @@
+<?php
+
+use Genero\Sage\CacheTags\Stores\TransientStore;
+use Genero\Sage\CacheTags\Stores\WordpressDbStore;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Stores\WordpressDbStore
+ * @covers \Genero\Sage\CacheTags\Stores\TransientStore
+ */
+class TestStore extends WP_UnitTestCase
+{
+    /** @return iterable<string, array{0: callable}> */
+    public function stores(): iterable
+    {
+        yield 'database' => [fn () => new WordpressDbStore];
+        yield 'transient' => [fn () => new TransientStore];
+    }
+
+    /**
+     * @dataProvider stores
+     */
+    public function test_save_get_and_clear_round_trip(callable $make): void
+    {
+        $store = $make();
+        $store->save(['post:1', 'archive:post'], '/a/');
+        $store->save(['post:1'], '/b/');
+
+        $this->assertEqualsCanonicalizing(['/a/', '/b/'], $store->get(['post:1']));
+        $this->assertSame(['/a/'], $store->get(['archive:post']));
+        $this->assertSame([], $store->get(['post:999']));
+
+        $store->clear(['/a/'], ['post:1', 'archive:post']);
+
+        $this->assertSame(['/b/'], $store->get(['post:1']));
+        $this->assertSame([], $store->get(['archive:post']));
+    }
+
+    /**
+     * @dataProvider stores
+     */
+    public function test_save_is_idempotent(callable $make): void
+    {
+        $store = $make();
+        $store->save(['post:1'], '/a/');
+        $store->save(['post:1'], '/a/');
+
+        $this->assertSame(['/a/'], $store->get(['post:1']));
+    }
+
+    /**
+     * @dataProvider stores
+     */
+    public function test_flush_empties_the_store(callable $make): void
+    {
+        $store = $make();
+        $store->save(['post:1'], '/a/');
+
+        $store->flush();
+
+        $this->assertSame([], $store->get(['post:1']));
+    }
+
+    public function test_save_with_no_tags_is_a_noop(): void
+    {
+        $store = new WordpressDbStore;
+
+        $this->assertTrue($store->save([], '/a/'));
+        $this->assertSame([], $store->get(['post:1']));
+    }
+}

--- a/tests/unit/test-core-tags.php
+++ b/tests/unit/test-core-tags.php
@@ -61,4 +61,63 @@ class TestCoreTags extends WP_UnitTestCase
 
         $this->assertContains('administrator', $roles, 'Roles must be slugs, not display names');
     }
+
+    public function test_queried_object_maps_each_object_kind(): void
+    {
+        $post = self::factory()->post->create_and_get();
+        $termId = self::factory()->category->create();
+
+        $this->assertSame(["post:{$post->ID}"], CoreTags::queriedObject($post));
+        $this->assertSame(
+            ["term:{$termId}", "term:{$termId}:full"],
+            CoreTags::queriedObject(get_term($termId))
+        );
+        $this->assertSame(['archive:post'], CoreTags::queriedObject(get_post_type_object('post')));
+    }
+
+    public function test_query_tags_each_post_in_a_wp_query(): void
+    {
+        $ids = self::factory()->post->create_many(3, ['post_status' => 'publish']);
+        $query = new WP_Query(['post__in' => $ids, 'orderby' => 'post__in']);
+
+        $this->assertSame(
+            array_map(fn ($id) => "post:{$id}", $ids),
+            CoreTags::query($query)
+        );
+    }
+
+    public function test_any_user(): void
+    {
+        $this->assertSame(['role:editor'], CoreTags::anyUser('editor'));
+        $this->assertSame(['role:editor', 'role:author'], CoreTags::anyUser(['editor', 'author']));
+    }
+
+    public function test_menu_and_navigation(): void
+    {
+        $menuId = wp_create_nav_menu('Footer');
+
+        $this->assertSame(["menu:{$menuId}"], CoreTags::menu($menuId));
+
+        register_nav_menu('footer', 'Footer location');
+        set_theme_mod('nav_menu_locations', ['footer' => $menuId]);
+
+        $this->assertSame(["menu:{$menuId}"], CoreTags::navigation('footer'));
+        $this->assertSame([], CoreTags::navigation('missing-location'));
+    }
+
+    public function test_is_cacheable_predicates(): void
+    {
+        $this->assertTrue(CoreTags::isCacheablePostType('post'));
+        $this->assertFalse(CoreTags::isCacheablePostType('revision'));
+        $this->assertTrue(CoreTags::isCacheableTaxonomy('category'));
+        $this->assertFalse(CoreTags::isCacheableTaxonomy('nav_menu'));
+    }
+
+    public function test_is_cacheable_post_meta_excludes_protected_keys(): void
+    {
+        $postId = self::factory()->post->create();
+
+        $this->assertTrue(CoreTags::isCacheablePostMeta('subtitle', $postId));
+        $this->assertFalse(CoreTags::isCacheablePostMeta('_thumbnail_id', $postId));
+    }
 }

--- a/tests/unit/test-util.php
+++ b/tests/unit/test-util.php
@@ -1,0 +1,53 @@
+<?php
+
+use Genero\Sage\CacheTags\Util;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Util
+ */
+class TestUtil extends WP_UnitTestCase
+{
+    public function test_flatten_flattens_nested_arrays(): void
+    {
+        $this->assertSame(
+            ['a', 'b', 'c', 'd'],
+            Util::flatten(['a', ['b', ['c']], 'd'])
+        );
+    }
+
+    public function test_current_url_is_the_trailingslashed_request_url(): void
+    {
+        global $wp;
+        $wp->request = 'hello/world';
+
+        $this->assertSame(home_url('/hello/world/'), Util::currentUrl());
+    }
+
+    public function test_env_reads_environment_variables(): void
+    {
+        putenv('CACHETAGS_TEST_ENV=present');
+
+        $this->assertSame('present', Util::env('CACHETAGS_TEST_ENV'));
+        $this->assertFalse(Util::env('CACHETAGS_TEST_MISSING'));
+
+        putenv('CACHETAGS_TEST_ENV');
+    }
+
+    public function test_chunk_request_splits_into_size_bounded_chunks(): void
+    {
+        $request = ['tag' => array_map(fn ($i) => "post:{$i}", range(1, 20))];
+        $chunks = Util::chunkRequest($request, 40);
+
+        $this->assertGreaterThan(1, count($chunks), 'splits when over the size limit');
+        foreach ($chunks as $chunk) {
+            $this->assertLessThanOrEqual(40, strlen($chunk));
+        }
+    }
+
+    public function test_chunk_request_keeps_a_small_request_in_one_chunk(): void
+    {
+        $chunks = Util::chunkRequest(['a' => '1', 'b' => '2'], 1000);
+
+        $this->assertSame(['a=1&b=2'], $chunks);
+    }
+}


### PR DESCRIPTION
Closes #15. Substantial progress on #18.

## #15 — Purge symmetry

Several data-change events emitted tags but never **cleared** them, so cached content stayed stale. `Actions\Core` now also clears on:

| Event | Tags cleared |
|---|---|
| `delete_term` | `term:{id}`, `term:{id}:full`, `taxonomy:{tax}`, `taxonomy:{tax}:any` |
| `edit_comment` / `deleted_comment` | `comment:{id}`, `post:{postId}` |
| `before_delete_post` (permanent delete, skips trash transition) | `post:{id}`, `archive:{type}`, `taxonomy:{tax}`, `archive:{type}:any` |
| `set_user_role` (incl. programmatic; doesn't fire `profile_update`) | `user:{id}`, old **and** new `role:{slug}` |
| `added_post_meta` / `deleted_post_meta` | `post:{id}` (previously only `updated_`) |
| `added_term_meta` / `updated_term_meta` | `term:{id}`, `term:{id}:full` |
| `wp_update_nav_menu_item` | `menu:{id}` (previously only menu-level `wp_update_nav_menu`) |

`onPostMetaUpdate`'s first arg is now untyped since `deleted_post_meta` passes an array of ids (unused either way).

## #18 — Test coverage for pre-existing code

Added suites for code that had none:

- **`Util`** — `flatten`, `currentUrl`, `env`, `chunkRequest`.
- **Stores** — `WordpressDbStore` + `TransientStore` (save/get/clear/flush, idempotent save, empty-tags no-op) via a shared data provider; `DeferredClearStore` (defers to a scheduled cron + transient, `processPendingClear` delegates, save/get pass-through).
- **`NonceCron`** — schedule (once, `twicedaily`) / unschedule.
- **Invalidators** — `SiteGroundCacheInvalidator` (per-URL under threshold, bulk flush over it) and `SuperCacheInvalidator`, using recording stubs for the host-cache provider functions.
- **`CoreTags`** — `queriedObject`, `query(WP_Query)`, `navigation`/`menu`, `anyUser`, `isCacheable*` predicates.
- **`Core` clear events** — the new #15 handlers above.

**77 tests / 176 assertions** (up from 43), all green via wp-env; lint clean.

### Not yet covered (remaining #18 scope, for a follow-up)
Kinsta / Fastly (soft + hard) / WP Rocket / Debug invalidators; `Site`, `WooCommerce`, `Polylang`, `Gravityform` actions; `CacheTagStore`; WP-CLI / Acorn console commands; `Bootstrap` / `CacheTagsServiceProvider` wiring. I left #18 open and noted these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)