### PR TITLE
Expand front-end tagging coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,25 @@ add_filter('cachetags/max-tag-length', fn () => 191);
 add_filter('cachetags/tag-pattern', fn () => '/^[^\s\x00-\x1F]+$/');
 ```
 
+## Front-end tagging
+
+With the `Core` action enabled, rendered pages are tagged automatically from the
+template (single/page, taxonomy, author, post-type/date/search archives,
+attachments) and from core blocks (queries, terms, authors, comments,
+calendar/archives, site title/tagline/logo, etc.). Classic-theme `wp_nav_menu()`
+output is tagged with its `menu:{id}` so menu edits purge the pages showing it.
+
+Site-identity blocks (`core/site-title`, `core/site-tagline`, `core/site-logo`)
+are tagged with an `option:{name}` tag and purged when that option changes.
+Adjust which options are tracked with the `cachetags/options` filter:
+
+```php
+add_filter('cachetags/options', fn (array $options) => [...$options, 'my_option']);
+```
+
+Options not bound to a specific block are usually better handled with a full
+cache flush than by tagging every page that might render them.
+
 ## Traits for use with roots/sage
 
 ### Composers

--- a/src/Actions/Core.php
+++ b/src/Actions/Core.php
@@ -18,6 +18,7 @@ class Core implements Action
     {
         \add_action('template_redirect', [$this, 'addTemplateCacheTags']);
         \add_filter('render_block', [$this, 'addBlockCacheTags'], 10, 3);
+        \add_filter('wp_nav_menu_args', [$this, 'addNavMenuCacheTags']);
 
         // Clear caches
         \add_action('transition_post_status', [$this, 'onPostStatusTransition'], 10, 3);
@@ -35,6 +36,7 @@ class Core implements Action
         \add_action('updated_term_meta', [$this, 'onTermMetaUpdate'], 10, 3);
         \add_action('added_term_meta', [$this, 'onTermMetaUpdate'], 10, 3);
         \add_action('edit_attachment', [$this, 'onAttachmentEdit']);
+        \add_action('updated_option', [$this, 'onOptionUpdate'], 10, 3);
         \add_action('wp_update_nav_menu', [$this, 'onMenuUpdate']);
         \add_action('wp_update_nav_menu_item', [$this, 'onMenuUpdate']);
         \add_action('delete_user', [$this, 'onUserDelete'], 10, 3);
@@ -81,7 +83,37 @@ class Core implements Action
                     ...CoreTags::users(get_query_var('author')),
                 ]);
                 break;
+            case is_attachment():
+                $this->cacheTags->add([
+                    ...CoreTags::queriedObject(),
+                ]);
+                break;
+            case is_date():
+            case is_search():
+                // Listings of any post that publishes/unpublishes into them.
+                $this->cacheTags->add([
+                    ...CoreTags::archive('post'),
+                ]);
+                break;
         }
+    }
+
+    /**
+     * Tag the menu rendered by a classic-theme wp_nav_menu() call. Block-theme
+     * navigation is tagged via its wp_navigation post id in addBlockCacheTags.
+     *
+     * @param  array<string, mixed>  $args
+     * @return array<string, mixed>
+     */
+    public function addNavMenuCacheTags(array $args): array
+    {
+        if (! empty($args['theme_location'])) {
+            $this->cacheTags->add(CoreTags::navigation($args['theme_location']));
+        } elseif (! empty($args['menu'])) {
+            $this->cacheTags->add(CoreTags::menu($args['menu']));
+        }
+
+        return $args;
     }
 
     /**
@@ -104,6 +136,10 @@ class Core implements Action
             $tags[] = CoreTags::posts($instance->context['postId']);
         }
 
+        if (isset($instance->context['commentId'])) {
+            $tags[] = CoreTags::comments($instance->context['commentId']);
+        }
+
         if (isset($attributes['ref'])) {
             // @note that these realistically these might be deleted and point to unexisting posts
             $tags[] = CoreTags::posts($attributes['ref']);
@@ -114,7 +150,26 @@ class Core implements Action
                 $tags[] = CoreTags::anyTerm('category');
                 break;
             case 'core/comments':
-                // @TODO could get individual comments
+                // Individual comments are tagged via the commentId context on
+                // the comment-template inner blocks above.
+                break;
+            case 'core/archives':
+            case 'core/calendar':
+                $tags[] = CoreTags::archive('post');
+                break;
+            case 'core/avatar':
+                if (! empty($attributes['userId'])) {
+                    $tags[] = CoreTags::users($attributes['userId']);
+                }
+                break;
+            case 'core/site-title':
+                $tags[] = CoreTags::option('blogname');
+                break;
+            case 'core/site-tagline':
+                $tags[] = CoreTags::option('blogdescription');
+                break;
+            case 'core/site-logo':
+                $tags[] = CoreTags::option('site_logo');
                 break;
             case 'core/post-author-name':
             case 'core/post-author':
@@ -401,6 +456,20 @@ class Core implements Action
         $this->cacheTags->clear([
             ...CoreTags::terms($termId),
             ...CoreTags::termPages($termId),
+        ]);
+    }
+
+    /**
+     * When a tracked site option changes, clear pages that render it.
+     */
+    public function onOptionUpdate(string $option, $oldValue, $newValue): void
+    {
+        if (! in_array($option, CoreTags::getCacheableOptions(), true)) {
+            return;
+        }
+
+        $this->cacheTags->clear([
+            ...CoreTags::option($option),
         ]);
     }
 

--- a/src/Tags/CoreTags.php
+++ b/src/Tags/CoreTags.php
@@ -444,4 +444,36 @@ class CoreTags
         // user mutations elsewhere clear role tags by slug.
         return array_keys(\wp_roles()->get_names());
     }
+
+    /**
+     * Return cache tags for one or multiple site options.
+     *
+     * @param  string|string[]  $options
+     * @return string[]
+     */
+    public static function option($options): array
+    {
+        return array_map(
+            fn ($option) => sprintf('option:%s', $option),
+            is_array($options) ? $options : [$options]
+        );
+    }
+
+    /**
+     * Site options that map to an `option:` tag emitted by a block (site-title,
+     * site-tagline, site-logo) and so should purge those pages when changed.
+     *
+     * Options not bound to a specific block are better handled with a full
+     * flush than by tagging every page that might depend on them.
+     *
+     * @return string[]
+     */
+    public static function getCacheableOptions(): array
+    {
+        return \apply_filters('cachetags/options', [
+            'blogname',
+            'blogdescription',
+            'site_logo',
+        ]);
+    }
 }

--- a/tests/integration/test-block-tags.php
+++ b/tests/integration/test-block-tags.php
@@ -1,0 +1,70 @@
+<?php
+
+use Genero\Sage\CacheTags\Actions\Core;
+use Genero\Sage\CacheTags\Tests\RestTestCase;
+
+/**
+ * Front-end block tagging (Core::addBlockCacheTags / addNavMenuCacheTags).
+ *
+ * @covers \Genero\Sage\CacheTags\Actions\Core
+ */
+class TestBlockTags extends RestTestCase
+{
+    /** Tags accumulated while rendering block markup. */
+    private function renderedTags(string $markup): array
+    {
+        $this->resetCacheTags();
+        do_blocks($markup);
+
+        return $this->cacheTags->get();
+    }
+
+    public function test_archives_and_calendar_blocks_tag_the_post_archive(): void
+    {
+        $this->assertContains('archive:post', $this->renderedTags('<!-- wp:archives /-->'));
+        $this->assertContains('archive:post', $this->renderedTags('<!-- wp:calendar /-->'));
+    }
+
+    public function test_avatar_block_tags_its_user(): void
+    {
+        $userId = self::factory()->user->create();
+
+        $this->assertContains("user:{$userId}", $this->renderedTags('<!-- wp:avatar {"userId":'.$userId.'} /-->'));
+    }
+
+    public function test_site_identity_blocks_tag_their_options(): void
+    {
+        $this->assertContains('option:blogname', $this->renderedTags('<!-- wp:site-title /-->'));
+        $this->assertContains('option:blogdescription', $this->renderedTags('<!-- wp:site-tagline /-->'));
+        $this->assertContains('option:site_logo', $this->renderedTags('<!-- wp:site-logo /-->'));
+    }
+
+    public function test_comment_template_blocks_tag_the_comment_via_context(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $commentId = self::factory()->comment->create(['comment_post_ID' => $postId]);
+
+        $this->resetCacheTags();
+        $block = new WP_Block(['blockName' => 'core/comment-content'], ['commentId' => $commentId]);
+        (new Core($this->cacheTags))->addBlockCacheTags('', ['blockName' => 'core/comment-content'], $block);
+
+        $this->assertContains("comment:{$commentId}", $this->cacheTags->get());
+    }
+
+    public function test_classic_nav_menu_render_tags_the_menu(): void
+    {
+        $menuId = wp_create_nav_menu('Primary');
+        register_nav_menu('primary', 'Primary');
+        set_theme_mod('nav_menu_locations', ['primary' => $menuId]);
+        wp_update_nav_menu_item($menuId, 0, [
+            'menu-item-title' => 'Home',
+            'menu-item-url' => home_url('/'),
+            'menu-item-status' => 'publish',
+        ]);
+
+        $this->resetCacheTags();
+        wp_nav_menu(['theme_location' => 'primary', 'echo' => false]);
+
+        $this->assertContains("menu:{$menuId}", $this->cacheTags->get());
+    }
+}

--- a/tests/integration/test-clear-events.php
+++ b/tests/integration/test-clear-events.php
@@ -100,6 +100,25 @@ class TestClearEvents extends RestTestCase
         $this->assertContains("term:{$termId}:full", $tags);
     }
 
+    public function test_updating_a_tagged_option_clears_it(): void
+    {
+        $this->resetCacheTags();
+
+        update_option('blogname', 'A different site name');
+
+        $this->assertContains('option:blogname', $this->queuedPurgeTags());
+    }
+
+    public function test_updating_an_untracked_option_clears_nothing(): void
+    {
+        update_option('cachetags_untracked', 'initial');
+        $this->resetCacheTags();
+
+        update_option('cachetags_untracked', 'changed');
+
+        $this->assertNotContains('option:cachetags_untracked', $this->queuedPurgeTags());
+    }
+
     public function test_updating_a_nav_menu_item_clears_the_menu(): void
     {
         $menuId = wp_create_nav_menu('Primary');

--- a/tests/integration/test-template-tags.php
+++ b/tests/integration/test-template-tags.php
@@ -1,0 +1,47 @@
+<?php
+
+use Genero\Sage\CacheTags\Actions\Core;
+use Genero\Sage\CacheTags\Tests\RestTestCase;
+
+/**
+ * Front-end template tagging (Core::addTemplateCacheTags).
+ *
+ * @covers \Genero\Sage\CacheTags\Actions\Core
+ */
+class TestTemplateTags extends RestTestCase
+{
+    /** Tags added for the template that would render the given URL. */
+    private function templateTags(string $url): array
+    {
+        $this->resetCacheTags();
+        $this->go_to($url);
+        (new Core($this->cacheTags))->addTemplateCacheTags();
+
+        return $this->cacheTags->get();
+    }
+
+    public function test_search_results_are_tagged_as_a_post_archive(): void
+    {
+        $this->assertContains('archive:post', $this->templateTags(home_url('/?s=hello')));
+    }
+
+    public function test_date_archive_is_tagged(): void
+    {
+        self::factory()->post->create(['post_status' => 'publish', 'post_date' => '2020-01-15 12:00:00']);
+
+        $this->assertContains('archive:post', $this->templateTags(home_url('/?year=2020&monthnum=1')));
+    }
+
+    public function test_attachment_page_is_tagged(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $attachmentId = self::factory()->attachment->create_object('image.jpg', $postId, [
+            'post_mime_type' => 'image/jpeg',
+        ]);
+
+        $this->assertContains(
+            "post:{$attachmentId}",
+            $this->templateTags(home_url('/?attachment_id='.$attachmentId))
+        );
+    }
+}


### PR DESCRIPTION
Closes #16.

Adds cache tags for front-end (non-REST) rendered output that previously went untagged, so it's purged when its data changes.

## Templates (`Core::addTemplateCacheTags`)
- `is_attachment` → the attachment post
- `is_date` / `is_search` → `archive:post` (refreshes when posts publish/unpublish into the listing)

## Blocks (`Core::addBlockCacheTags`)
- `core/archives`, `core/calendar` → `archive:post`
- `core/avatar` → `user:{id}`
- `core/site-title` / `core/site-tagline` / `core/site-logo` → `option:{name}`
- comment-template inner blocks → `comment:{id}` via the `commentId` block context

## Navigation
- Classic-theme `wp_nav_menu()` output is now tagged with `menu:{id}` (hooked on `wp_nav_menu_args`), so menu edits purge classic-theme pages. Block-theme navigation was already covered via the `wp_navigation` `ref`.

## Site options
- `CoreTags::option()` + a filterable `getCacheableOptions()` (`blogname`, `blogdescription`, `site_logo`). Pages rendering the site-identity blocks are purged on `updated_option`. Per the discussion, options **not** bound to a specific block are intentionally left to a full flush rather than tagging every page.

## Per review
Inline `core/image` / `core/cover` attachments are **not** tagged — only alt text changes them, which is too rare/granular to justify the tag volume.

**87 tests / 189 assertions** green via wp-env (new `test-block-tags.php`, `test-template-tags.php`, plus option-purge cases in `test-clear-events.php`); lint clean.

### Deferred (noted in #16, lower value)
Classic `dynamic_sidebar` widgets, `core/template-part` container, `core/post-navigation-link`, `core/shortcode`; block-theme `wp_navigation`/`wp_block` are `_builtin` so their `ref` tags aren't purged on edit (shared FSE-types concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)