### PR TITLE
Store the true cacheable URL by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,26 +79,27 @@ Currently it supports Kinsta Page Cache, WP Super Cache, SiteGround Optimizer an
 
 ### Stored URL and query strings
 
-Front-end pages are stored under their **path only** by default. This is correct
-for the common cases: Fastly purges by `Surrogate-Key` (tag), ignoring the URL,
-and Kinsta doesn't cache query-string URLs at all (they bypass to PHP), so there
-is no query-string variant to purge. URL-based invalidators then purge the path,
-which is what was cached.
+Front-end pages are stored under the **actual requested URL** (including its query
+string), so a URL-based purge matches the variant a page cache keyed on. A default
+set of tracking/volatile params (`utm_*`, `gclid`/`fbclid`/`dclid`/…, `_wpnonce`,
+`_`) is stripped and the rest sorted; keys longer than the `varchar(191)` column
+fall back to the path.
 
-If you run a URL-keyed cache that **does** cache query-string variants separately
-(SiteGround, or Kinsta configured to cache GET params), opt in so the stored URL
-matches the cached entry and the variant is actually purged:
+On a **query-bypass** edge — Fastly (purges by `Surrogate-Key`, ignores the URL)
+or Kinsta (query-string URLs bypass the cache entirely) — those query-string rows
+are never cached and so never need purging; they just accumulate in the store
+(one row per visited `?…` combination, including bot/scanner params). A
+query-bypass site with heavy parameterised traffic can keep the store lean by
+storing the path only:
 
 ```php
-add_filter('cachetags/store-query-string', '__return_true');
+add_filter('cachetags/store-query-string', '__return_false');
 ```
 
-A default set of tracking/volatile params (`utm_*`, `gclid`/`fbclid`/`dclid`/…,
-`_wpnonce`, `_`) is stripped and the rest sorted, so the store doesn't bloat with
-campaign-link variants. **To actually match a URL-keyed edge the strip list must
-equal that edge's** — and that's site-specific (our own Fastly VCLs strip
-anywhere from 5 to 16 params), so align it per site with
-`cachetags/url-ignored-params`:
+**To match a URL-keyed edge that does cache query strings** (SiteGround, or Kinsta
+configured to cache GET params) the strip list must equal that edge's — and that's
+site-specific (our own Fastly VCLs strip anywhere from 5 to 16 params), so align
+it per site:
 
 ```php
 add_filter('cachetags/url-ignored-params', fn ($p) => [...$p, 'campaign_id', 'tduid']);

--- a/README.md
+++ b/README.md
@@ -77,6 +77,28 @@ across all sites.
 
 Currently it supports Kinsta Page Cache, WP Super Cache, SiteGround Optimizer and Fastly. You can use multiple invalidators if you eg use Fastly in front of Kinsta and want to invalidate both.
 
+### Stored URL and query strings
+
+Front-end pages are stored under their **path only** by default. This is correct
+for the common cases: Fastly purges by `Surrogate-Key` (tag), ignoring the URL,
+and Kinsta doesn't cache query-string URLs at all (they bypass to PHP), so there
+is no query-string variant to purge. URL-based invalidators then purge the path,
+which is what was cached.
+
+If you run a URL-keyed cache that **does** cache query-string variants separately
+(SiteGround, or Kinsta configured to cache GET params), opt in so the stored URL
+matches the cached entry and the variant is actually purged:
+
+```php
+add_filter('cachetags/store-query-string', '__return_true');
+```
+
+Tracking/volatile params (`utm_*`, `gclid`, `fbclid`, `_wpnonce`, `_`) are
+stripped and the rest sorted, so the key matches the edge and the store doesn't
+bloat. Adjust the strip list with `cachetags/url-ignored-params`. (Comprehensive
+param normalization — an allow-list at the edge — is better handled in the
+CDN/VCL than here.)
+
 ### SiteGround Optimizer
 
 Integration exists if you add the `SiteGroundCacheInvalidator` invalidator in the `config/cachetags.php` file.

--- a/README.md
+++ b/README.md
@@ -93,11 +93,19 @@ matches the cached entry and the variant is actually purged:
 add_filter('cachetags/store-query-string', '__return_true');
 ```
 
-Tracking/volatile params (`utm_*`, `gclid`, `fbclid`, `_wpnonce`, `_`) are
-stripped and the rest sorted, so the key matches the edge and the store doesn't
-bloat. Adjust the strip list with `cachetags/url-ignored-params`. (Comprehensive
-param normalization — an allow-list at the edge — is better handled in the
-CDN/VCL than here.)
+A default set of tracking/volatile params (`utm_*`, `gclid`/`fbclid`/`dclid`/…,
+`_wpnonce`, `_`) is stripped and the rest sorted, so the store doesn't bloat with
+campaign-link variants. **To actually match a URL-keyed edge the strip list must
+equal that edge's** — and that's site-specific (our own Fastly VCLs strip
+anywhere from 5 to 16 params), so align it per site with
+`cachetags/url-ignored-params`:
+
+```php
+add_filter('cachetags/url-ignored-params', fn ($p) => [...$p, 'campaign_id', 'tduid']);
+```
+
+Comprehensive query-param normalization is better done at the edge (CDN/VCL) than
+replicated here.
 
 ### SiteGround Optimizer
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -92,10 +92,22 @@ class Util
     }
 
     /**
-     * Tracking/volatile params that no page cache keys on. Stripped from the
-     * stored URL so they don't bloat the store or mismatch the cached entry.
+     * Tracking/volatile params dropped from the stored URL when the query
+     * string is included, so it doesn't bloat the store. This is a generic
+     * starting default — to actually *match* a URL-keyed edge it must equal
+     * that edge's own strip list, which is site-specific (our Fastly VCLs strip
+     * anywhere from 5 to 16 params: beamex strips utm_*/gclid only, herrfors
+     * also strips campaign_id, tduid, gad_source, wbraid, dclid, _gl, …). Align
+     * it per site via cachetags/url-ignored-params; comprehensive normalization
+     * belongs at the edge.
      */
-    const IGNORED_URL_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'fbclid', '_wpnonce', '_'];
+    const IGNORED_URL_PARAMS = [
+        // Campaign / click trackers (Google, Microsoft, Facebook, GA linker).
+        'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_id',
+        'gclid', 'gad_source', 'gbraid', 'wbraid', 'dclid', 'fbclid', 'msclkid', '_gl',
+        // Volatile WordPress per-request params.
+        '_wpnonce', '_',
+    ];
 
     public static function currentUrl(): string
     {
@@ -103,12 +115,13 @@ class Util
 
         $url = trailingslashit(home_url($wp->request));
 
-        // Path-only by default: correct where the edge purges by tag (Fastly,
-        // ignores the URL) or never caches query-string URLs (Kinsta bypasses
-        // them). Sites on a URL-keyed cache that *does* cache query strings
-        // (SiteGround, or Kinsta configured to cache GET params) opt in, so the
-        // stored URL matches the cached entry and the variant is actually
-        // purged — at the cost of one store row per visited query combination.
+        // Path-only by default. For Fastly this is moot — it purges by
+        // Surrogate-Key (tag) and never reads the stored URL. For Kinsta it
+        // matches what's actually cached, since query-string URLs bypass the
+        // cache entirely. Opt in only on a URL-keyed cache that *does* cache
+        // query strings (SiteGround, or Kinsta set to cache GET params), so the
+        // stored URL matches the cached variant — at the cost of one store row
+        // per visited query combination.
         if (empty($_GET) || ! apply_filters('cachetags/store-query-string', false)) {
             return $url;
         }

--- a/src/Util.php
+++ b/src/Util.php
@@ -115,14 +115,13 @@ class Util
 
         $url = trailingslashit(home_url($wp->request));
 
-        // Path-only by default. For Fastly this is moot — it purges by
-        // Surrogate-Key (tag) and never reads the stored URL. For Kinsta it
-        // matches what's actually cached, since query-string URLs bypass the
-        // cache entirely. Opt in only on a URL-keyed cache that *does* cache
-        // query strings (SiteGround, or Kinsta set to cache GET params), so the
-        // stored URL matches the cached variant — at the cost of one store row
-        // per visited query combination.
-        if (empty($_GET) || ! apply_filters('cachetags/store-query-string', false)) {
+        // Store the actual requested URL — the variant a URL-keyed page cache
+        // would key on — so a purge matches what was cached. Moot for Fastly
+        // (purges by Surrogate-Key, ignores the URL); on Kinsta the query-string
+        // variants bypass the cache, so the extra rows just accumulate. A
+        // query-bypass site with heavy bot/param traffic can opt out to keep the
+        // store lean and avoid no-op purge calls for never-cached URLs.
+        if (empty($_GET) || ! apply_filters('cachetags/store-query-string', true)) {
             return $url;
         }
 
@@ -135,8 +134,11 @@ class Util
 
         ksort($params);
         $params = map_deep(wp_unslash($params), 'sanitize_text_field');
+        $full = $url.'?'.http_build_query($params);
 
-        return $url.'?'.http_build_query($params);
+        // The url column is varchar(191); fall back to the path if the query
+        // string overflows it, which also bounds pathological junk-param keys.
+        return strlen($full) <= apply_filters('cachetags/max-url-length', 191) ? $full : $url;
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -96,7 +96,7 @@ class Util
      * string is included, so it doesn't bloat the store. This is a generic
      * starting default — to actually *match* a URL-keyed edge it must equal
      * that edge's own strip list, which is site-specific (our Fastly VCLs strip
-     * anywhere from 5 to 16 params: beamex strips utm_*/gclid only, herrfors
+     * anywhere from 5 to 16 params: beamex strips only utm_ and gclid, herrfors
      * also strips campaign_id, tduid, gad_source, wbraid, dclid, _gl, …). Align
      * it per site via cachetags/url-ignored-params; comprehensive normalization
      * belongs at the edge.

--- a/src/Util.php
+++ b/src/Util.php
@@ -91,11 +91,39 @@ class Util
         );
     }
 
+    /**
+     * Tracking/volatile params that no page cache keys on. Stripped from the
+     * stored URL so they don't bloat the store or mismatch the cached entry.
+     */
+    const IGNORED_URL_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'fbclid', '_wpnonce', '_'];
+
     public static function currentUrl(): string
     {
         global $wp;
 
-        return trailingslashit(home_url($wp->request));
+        $url = trailingslashit(home_url($wp->request));
+
+        // Path-only by default: correct where the edge purges by tag (Fastly,
+        // ignores the URL) or never caches query-string URLs (Kinsta bypasses
+        // them). Sites on a URL-keyed cache that *does* cache query strings
+        // (SiteGround, or Kinsta configured to cache GET params) opt in, so the
+        // stored URL matches the cached entry and the variant is actually
+        // purged — at the cost of one store row per visited query combination.
+        if (empty($_GET) || ! apply_filters('cachetags/store-query-string', false)) {
+            return $url;
+        }
+
+        $ignored = apply_filters('cachetags/url-ignored-params', self::IGNORED_URL_PARAMS);
+        $params = array_diff_key($_GET, array_flip($ignored));
+
+        if (empty($params)) {
+            return $url;
+        }
+
+        ksort($params);
+        $params = map_deep(wp_unslash($params), 'sanitize_text_field');
+
+        return $url.'?'.http_build_query($params);
     }
 
     /**

--- a/tests/integration/test-store-url.php
+++ b/tests/integration/test-store-url.php
@@ -1,0 +1,73 @@
+<?php
+
+use Genero\Sage\CacheTags\Util;
+
+/**
+ * The URL a front-end page's tags are stored under.
+ *
+ * @covers \Genero\Sage\CacheTags\Util::currentUrl
+ */
+class TestStoreUrl extends WP_UnitTestCase
+{
+    private array $get;
+
+    public function set_up(): void
+    {
+        parent::set_up();
+        $this->set_permalink_structure('/%postname%/');
+        $this->get = $_GET;
+        global $wp;
+        $wp->request = 'shop';
+    }
+
+    public function tear_down(): void
+    {
+        $_GET = $this->get;
+        parent::tear_down();
+    }
+
+    public function test_is_path_only_by_default(): void
+    {
+        $_GET = ['orderby' => 'price'];
+
+        $url = Util::currentUrl();
+
+        $this->assertStringEndsWith('/shop/', $url);
+        $this->assertStringNotContainsString('?', $url);
+    }
+
+    public function test_includes_sorted_query_when_opted_in(): void
+    {
+        $_GET = ['orderby' => 'price', 'colour' => 'blue'];
+        add_filter('cachetags/store-query-string', '__return_true');
+
+        $url = Util::currentUrl();
+
+        // Sorted, so the same URL is keyed regardless of param order.
+        $this->assertStringEndsWith('/shop/?colour=blue&orderby=price', $url);
+    }
+
+    public function test_strips_tracking_params_when_opted_in(): void
+    {
+        $_GET = ['utm_source' => 'newsletter', 'gclid' => 'x', 'fbclid' => 'y', '_' => '123'];
+        add_filter('cachetags/store-query-string', '__return_true');
+
+        $url = Util::currentUrl();
+
+        // Only tracking/volatile params present → nothing keyworthy left.
+        $this->assertStringEndsWith('/shop/', $url);
+        $this->assertStringNotContainsString('?', $url);
+    }
+
+    public function test_ignored_params_are_filterable(): void
+    {
+        $_GET = ['ref' => 'campaign', 'orderby' => 'price'];
+        add_filter('cachetags/store-query-string', '__return_true');
+        add_filter('cachetags/url-ignored-params', fn ($p) => [...$p, 'ref']);
+
+        $url = Util::currentUrl();
+
+        $this->assertStringEndsWith('/shop/?orderby=price', $url);
+        $this->assertStringNotContainsString('ref', $url);
+    }
+}

--- a/tests/integration/test-store-url.php
+++ b/tests/integration/test-store-url.php
@@ -26,20 +26,9 @@ class TestStoreUrl extends WP_UnitTestCase
         parent::tear_down();
     }
 
-    public function test_is_path_only_by_default(): void
-    {
-        $_GET = ['orderby' => 'price'];
-
-        $url = Util::currentUrl();
-
-        $this->assertStringEndsWith('/shop/', $url);
-        $this->assertStringNotContainsString('?', $url);
-    }
-
-    public function test_includes_sorted_query_when_opted_in(): void
+    public function test_includes_the_sorted_query_string_by_default(): void
     {
         $_GET = ['orderby' => 'price', 'colour' => 'blue'];
-        add_filter('cachetags/store-query-string', '__return_true');
 
         $url = Util::currentUrl();
 
@@ -47,14 +36,30 @@ class TestStoreUrl extends WP_UnitTestCase
         $this->assertStringEndsWith('/shop/?colour=blue&orderby=price', $url);
     }
 
-    public function test_strips_tracking_params_when_opted_in(): void
+    public function test_no_query_string_stays_path_only(): void
     {
-        $_GET = ['utm_source' => 'newsletter', 'gclid' => 'x', 'fbclid' => 'y', '_' => '123'];
-        add_filter('cachetags/store-query-string', '__return_true');
+        $_GET = [];
+
+        $this->assertStringEndsWith('/shop/', Util::currentUrl());
+    }
+
+    public function test_can_opt_out_to_path_only(): void
+    {
+        $_GET = ['orderby' => 'price'];
+        add_filter('cachetags/store-query-string', '__return_false');
 
         $url = Util::currentUrl();
 
-        // Only tracking/volatile params present → nothing keyworthy left.
+        $this->assertStringEndsWith('/shop/', $url);
+        $this->assertStringNotContainsString('?', $url);
+    }
+
+    public function test_strips_tracking_and_volatile_params(): void
+    {
+        $_GET = ['utm_source' => 'newsletter', 'gclid' => 'x', 'fbclid' => 'y', '_' => '123'];
+
+        $url = Util::currentUrl();
+
         $this->assertStringEndsWith('/shop/', $url);
         $this->assertStringNotContainsString('?', $url);
     }
@@ -62,12 +67,21 @@ class TestStoreUrl extends WP_UnitTestCase
     public function test_ignored_params_are_filterable(): void
     {
         $_GET = ['ref' => 'campaign', 'orderby' => 'price'];
-        add_filter('cachetags/store-query-string', '__return_true');
         add_filter('cachetags/url-ignored-params', fn ($p) => [...$p, 'ref']);
 
         $url = Util::currentUrl();
 
         $this->assertStringEndsWith('/shop/?orderby=price', $url);
         $this->assertStringNotContainsString('ref', $url);
+    }
+
+    public function test_overlong_query_string_falls_back_to_the_path(): void
+    {
+        $_GET = ['q' => str_repeat('a', 300)];
+
+        $url = Util::currentUrl();
+
+        $this->assertStringEndsWith('/shop/', $url, 'a key over the varchar(191) column falls back to the path');
+        $this->assertStringNotContainsString('?', $url);
     }
 }


### PR DESCRIPTION
Closes #30.

The tag store now keys front-end pages by the **actual requested URL** (query string included), not path-only, so a URL-based purge matches the variant a page cache keyed on. `cachetags/store-query-string` defaults to **true**.

### Behaviour
- Tracking/volatile params (`utm_*`, `gclid`/`fbclid`/`dclid`/`msclkid`/`_gl`/…, `_wpnonce`, `_`) are stripped and the rest sorted. The list is a generic default — to match a URL-keyed edge it must equal that edge's, which is site-specific (our Fastly VCLs strip 5→16 params and all differ), so align via `cachetags/url-ignored-params`.
- Keys longer than the `varchar(191)` url column fall back to the path (bounds overflow + pathological junk-param keys).

### Trade-off (documented in README)
On a **query-bypass** edge — Fastly (purges by tag, ignores the URL) or Kinsta (query-string URLs bypass the cache) — those query-string rows are never cached and never need purging; they just accumulate (one row per visited `?…` combo, including bot/scanner params, since there's no allow-list). Such a site can opt out:

```php
add_filter('cachetags/store-query-string', '__return_false');
```

This is the maintainer-preferred correctness-by-default: the store records the real URL, robust to an edge's query-string behaviour changing (Kinsta reconfigured, a move to SiteGround). 6 dedicated tests + full suite (93) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)