### PR TITLE
Document handling nonces in cached pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,41 @@ add_filter('cachetags/options', fn (array $options) => [...$options, 'my_option'
 Options not bound to a specific block are usually better handled with a full
 cache flush than by tagging every page that might render them.
 
+## Nonces in cached pages
+
+A page cached for hours can ship a **stale nonce**. WordPress nonces are valid
+for 12–24h; once one ages out, the action it guards (a form submit, an AJAX
+"load more", an add-to-cart) starts failing for everyone served the cached page.
+
+Two ways to handle a page that bakes a nonce into its HTML:
+
+1. **Tag it `nonce` and enable the nonce cron.** The page is then purged every
+   12 hours, before any embedded nonce can expire. Enable `'nonce-cron' => true`
+   in the config (or `->nonceCron()` on `Bootstrap`), and add the tag wherever
+   the nonce is rendered:
+
+   ```php
+   // e.g. a product page that prints a WooCommerce Store API nonce for add-to-cart
+   add_action('wp_footer', function () {
+       if (function_exists('is_product') && is_product()) {
+           \Genero\Sage\CacheTags\CacheTags::getInstance()?->add(['nonce']);
+       }
+   });
+   ```
+
+   The `Gravityform` action already does this for file-upload fields.
+
+2. **Mark it non-cacheable** when the page also shows genuinely real-time data
+   (e.g. live availability), where a 12h refresh isn't enough:
+
+   ```php
+   add_filter('cachetags/cacheable', fn ($c) => is_page('booking') ? false : $c);
+   ```
+
+Note that modern WooCommerce (10.7+) refetches the Store API nonce client-side
+before a write, so the sitewide Store API nonce is no longer a staleness risk on
+its own — only nonces that are actually *used as rendered* need this treatment.
+
 ## Traits for use with roots/sage
 
 ### Composers


### PR DESCRIPTION
Closes #26.

The `nonce` tag + nonce cron already exist (Gravity Forms file-uploads use them); the gap was guidance. Adds a "Nonces in cached pages" README section covering the two remedies — tag `nonce` + enable the cron (12h purge), or mark non-cacheable for real-time pages — with the WooCommerce Store API / add-to-cart example.

Scoped per discussion: no `wpdev-booking` handling and no Smash Balloon / social-wall docs. Also notes that modern WooCommerce (10.7+) refetches the Store API nonce client-side, so the sitewide nonce isn't a staleness risk on its own — only nonces *used as rendered* need this.

Docs-only (no code), so it's safe to merge independently of the other open PRs. Auto-detection (e.g. always tagging product pages) was deliberately left out: it's per-theme, has 12h-churn cost, and is mostly unnecessary post-WC-10.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)