### PR TITLE
Test coverage for Site, DebugComment, Fastly invalidator (batch 1 of #18)

### DIFF
--- a/tests/integration/test-debug-comment.php
+++ b/tests/integration/test-debug-comment.php
@@ -1,0 +1,31 @@
+<?php
+
+use Genero\Sage\CacheTags\Actions\DebugComment;
+use Genero\Sage\CacheTags\CacheTags;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Actions\DebugComment
+ */
+class TestDebugComment extends WP_UnitTestCase
+{
+    public function test_prints_the_url_and_human_readable_tags(): void
+    {
+        $cacheTags = CacheTags::getInstance();
+        $ref = new ReflectionProperty($cacheTags, 'cacheTags');
+        $ref->setAccessible(true);
+        $ref->setValue($cacheTags, []);
+
+        $postId = self::factory()->post->create(['post_title' => 'Hello World', 'post_status' => 'publish']);
+        $termId = self::factory()->category->create(['name' => 'News']);
+        $cacheTags->add(["post:{$postId}", "term:{$termId}"]);
+
+        ob_start();
+        (new DebugComment($cacheTags))->printCacheTagsDebug();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('sage-cachetags', $output);
+        $this->assertStringContainsString("post:{$postId}", $output);
+        $this->assertStringContainsString('Hello World', $output, 'post tag is labelled with its title');
+        $this->assertStringContainsString('News', $output, 'term tag is labelled with its name');
+    }
+}

--- a/tests/integration/test-fastly-invalidator.php
+++ b/tests/integration/test-fastly-invalidator.php
@@ -1,0 +1,50 @@
+<?php
+
+use Genero\Sage\CacheTags\Invalidators\FastlyCacheInvalidator;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Invalidators\FastlyCacheInvalidator
+ */
+class TestFastlyInvalidator extends WP_UnitTestCase
+{
+    private array $requests = [];
+
+    public function set_up(): void
+    {
+        parent::set_up();
+        $this->requests = [];
+        add_filter('pre_http_request', [$this, 'capture'], 10, 3);
+    }
+
+    public function capture($pre, $args, $url)
+    {
+        $this->requests[] = ['url' => $url, 'args' => $args];
+
+        return ['response' => ['code' => 200], 'body' => '{}'];
+    }
+
+    public function test_clear_purges_by_surrogate_key_and_ignores_the_urls(): void
+    {
+        $ok = (new FastlyCacheInvalidator)->clear(
+            ['https://example.com/a/', 'https://example.com/b/'],
+            ['post:1', 'term:5'],
+        );
+
+        $this->assertTrue($ok);
+        $this->assertCount(1, $this->requests, 'one purge call');
+        $this->assertStringContainsString('/purge/', $this->requests[0]['url']);
+
+        $body = json_decode($this->requests[0]['args']['body'], true);
+        $this->assertSame(['post:1', 'term:5'], $body['surrogate_keys']);
+        // Fastly purges by tag — the stored URLs are not sent.
+        $this->assertStringNotContainsString('example.com', wp_json_encode($body));
+    }
+
+    public function test_clear_returns_false_on_a_non_200_response(): void
+    {
+        remove_filter('pre_http_request', [$this, 'capture'], 10);
+        add_filter('pre_http_request', fn () => ['response' => ['code' => 403], 'body' => '{"msg":"nope"}']);
+
+        $this->assertFalse((new FastlyCacheInvalidator)->clear(['/a/'], ['post:1']));
+    }
+}

--- a/tests/integration/test-site-action.php
+++ b/tests/integration/test-site-action.php
@@ -1,0 +1,48 @@
+<?php
+
+use Genero\Sage\CacheTags\Actions\Site;
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tags\SiteTags;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Actions\Site
+ * @covers \Genero\Sage\CacheTags\Tags\SiteTags
+ */
+class TestSiteAction extends WP_UnitTestCase
+{
+    private function action(): Site
+    {
+        return new Site(CacheTags::getInstance());
+    }
+
+    public function test_prefixes_each_tag_with_the_current_site(): void
+    {
+        $id = get_current_blog_id();
+
+        $result = $this->action()->addSitePrefix(['post:1', 'term:5']);
+
+        $this->assertSame(["site:{$id}:post:1", "site:{$id}:term:5"], $result);
+    }
+
+    public function test_does_not_double_prefix_a_site_tag(): void
+    {
+        $id = get_current_blog_id();
+        $siteTag = SiteTags::sites()[0];
+
+        $result = $this->action()->addSitePrefix([$siteTag, 'post:1']);
+
+        $this->assertSame([$siteTag, "site:{$id}:post:1"], $result);
+    }
+
+    public function test_add_site_tag_adds_the_current_site(): void
+    {
+        $cacheTags = CacheTags::getInstance();
+        $ref = new ReflectionProperty($cacheTags, 'cacheTags');
+        $ref->setAccessible(true);
+        $ref->setValue($cacheTags, []);
+
+        $this->action()->addSiteTag();
+
+        $this->assertContains('site:'.get_current_blog_id(), $cacheTags->get());
+    }
+}


### PR DESCRIPTION
First batch toward #18 — covers clear gaps the existing suite left:

- **`Site`** — per-site tag prefixing (`site:{id}:tag`), site tags pass through un-prefixed, and `addSiteTag`.
- **`DebugComment`** — the rendered comment carries the URL plus human-readable labels (post title, term name).
- **`FastlyCacheInvalidator`** — mocked via `pre_http_request`: asserts it purges by `surrogate_keys` and **does not send the stored URLs**, and returns `false` on a non-200. (Also documents the tag-purge behavior that drove the cache-key investigation.)

Already covered before this PR: `Util`, `CoreTags`, tag normalization, REST URL/tagging, stores, database, deferred-clear, nonce-cron, SiteGround + Super Cache invalidators, block/template tags, clear events, purge symmetry.

**Still open on #18** (left as checkboxes there): Kinsta invalidator (raw `curl`, not WP-mockable without a wrapper), WP-Rocket invalidator, WP-CLI/Console commands, `Bootstrap`/`CacheTagsServiceProvider` wiring, and the remaining `Core`/`CoreTags` branches. Kept this batch to clean, deterministic wins; the rest can follow.

93 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)