### PR TITLE
Add KinstaGroupCacheInvalidator (prefix purges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,21 @@ Integration exists if you add the `SuperCacheInvalidator` invalidator in the `co
 
 ### Kinsta
 
-Integration exists if you add the `KinstaCacheInvalidator` in the `config/cachetags.php` file.
+Two invalidators, differing in how Kinsta resolves the purge:
+
+- **`KinstaGroupCacheInvalidator`** (recommended) purges by `group|` — a prefix
+  wildcard that clears a path together with everything beneath it: its pagination
+  (`/shop/page/2/`) and its query-string variants (`/shop/?orderby=…`) in one
+  request. It disables query-string storage (`cachetags/store-query-string`)
+  since the bare path is enough, keeping the store lean. This is the right choice
+  for a standard Kinsta setup, where query-string URLs bypass the cache anyway.
+- **`KinstaCacheInvalidator`** purges by `single|` — the exact URL only. Use this
+  if you've configured Kinsta to cache query-string URLs and need each variant
+  purged by its full stored URL (see [Stored URL and query strings](#stored-url-and-query-strings)).
+
+Add one of them to the `invalidator` list in `config/cachetags.php`. The site
+root (`/`) is always purged exactly, so a group purge never flushes the whole
+site.
 
 ### Cloudflare
 

--- a/src/Invalidators/KinstaCacheInvalidator.php
+++ b/src/Invalidators/KinstaCacheInvalidator.php
@@ -23,29 +23,41 @@ class KinstaCacheInvalidator implements Invalidator
             return false;
         }
 
-        $cleanedUrls = array_map(
-            fn ($url) => str_replace(['http://', 'https://'], '', $url),
-            $urls
-        );
-        $purgeRequest = [];
-        foreach ($cleanedUrls as $key => $url) {
-            $purgeRequest["single|$key"] = $url;
-        }
+        $requests = Util::chunkRequest($this->purgeList($urls), self::POST_MAX_BODY_SIZE);
 
-        $purgeRequest = apply_filters('KinstaCache/purgeImmediate', $purgeRequest);
-
-        $requests = Util::chunkRequest($purgeRequest, self::POST_MAX_BODY_SIZE);
         if (count($requests) > 3) {
-            $result = $this->flush();
-        } else {
-            $result = array_reduce(
-                $requests,
-                fn (bool $result, string $chunk) => $this->post(self::IMMEDIATE_PATH, $chunk) ? $result : false,
-                true
-            );
+            return $this->flush();
         }
 
-        return $result;
+        return array_reduce(
+            $requests,
+            fn (bool $result, string $chunk) => $this->post(self::IMMEDIATE_PATH, $chunk) ? $result : false,
+            true
+        );
+    }
+
+    /**
+     * Build the Kinsta purge request: a map of `<type>|<key>` => scheme-less URL.
+     *
+     * @param  string[]  $urls
+     * @return array<string, string>
+     */
+    public function purgeList(array $urls): array
+    {
+        $purgeRequest = [];
+        foreach ($urls as $key => $url) {
+            $purgeRequest[$this->purgeKey($key, $url)] = str_replace(['http://', 'https://'], '', $url);
+        }
+
+        return apply_filters('KinstaCache/purgeImmediate', $purgeRequest);
+    }
+
+    /**
+     * Purge-list key for a URL. `single|` purges the exact URL only.
+     */
+    protected function purgeKey(string|int $key, string $url): string
+    {
+        return "single|$key";
     }
 
     protected function post(string $endpoint, string $body): bool

--- a/src/Invalidators/KinstaGroupCacheInvalidator.php
+++ b/src/Invalidators/KinstaGroupCacheInvalidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Invalidators;
+
+/**
+ * Kinsta invalidator that purges by `group|` (prefix/wildcard) instead of
+ * `single|` (exact URL).
+ *
+ * A group purge clears a URL together with everything beneath it — its
+ * pagination (`/shop/page/2/`) and its query-string variants (`/shop/?orderby`)
+ * — in one request. So the bare path is all that needs storing; this invalidator
+ * disables query-string storage to keep the store lean and avoid purging URLs
+ * Kinsta never cached (query strings bypass its cache).
+ *
+ * Use this on a standard Kinsta setup. Use the plain `KinstaCacheInvalidator`
+ * (exact `single|` purges) if you've configured Kinsta to cache query-string
+ * URLs and need each variant purged by its full URL.
+ */
+class KinstaGroupCacheInvalidator extends KinstaCacheInvalidator
+{
+    public function __construct()
+    {
+        \add_filter('cachetags/store-query-string', '__return_false');
+    }
+
+    protected function purgeKey(string|int $key, string $url): string
+    {
+        // `group|` is a string-prefix wildcard — it clears the URL and every URL
+        // that starts with it. The site root ("/") would match the entire site,
+        // so purge that exactly. Trailing slashes keep "/shop/" from also
+        // matching "/shopping/".
+        $path = parse_url($url, PHP_URL_PATH) ?: '/';
+
+        return (rtrim($path, '/') === '' ? 'single|' : 'group|').$key;
+    }
+}

--- a/tests/integration/test-kinsta-invalidators.php
+++ b/tests/integration/test-kinsta-invalidators.php
@@ -1,0 +1,45 @@
+<?php
+
+use Genero\Sage\CacheTags\Invalidators\KinstaCacheInvalidator;
+use Genero\Sage\CacheTags\Invalidators\KinstaGroupCacheInvalidator;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Invalidators\KinstaCacheInvalidator
+ * @covers \Genero\Sage\CacheTags\Invalidators\KinstaGroupCacheInvalidator
+ */
+class TestKinstaInvalidators extends WP_UnitTestCase
+{
+    private array $urls = [
+        'shop' => 'https://example.com/shop/',
+        'home' => 'https://example.com/',
+    ];
+
+    public function test_default_invalidator_purges_each_url_exactly(): void
+    {
+        $list = (new KinstaCacheInvalidator)->purgeList($this->urls);
+
+        $this->assertSame([
+            'single|shop' => 'example.com/shop/',
+            'single|home' => 'example.com/',
+        ], $list);
+    }
+
+    public function test_group_invalidator_prefix_purges_paths_but_not_the_root(): void
+    {
+        $list = (new KinstaGroupCacheInvalidator)->purgeList($this->urls);
+
+        $this->assertSame([
+            // Prefix purge clears /shop/, /shop/page/2/, /shop/?orderby=… at once.
+            'group|shop' => 'example.com/shop/',
+            // The root would match the whole site, so it stays exact.
+            'single|home' => 'example.com/',
+        ], $list);
+    }
+
+    public function test_group_invalidator_disables_query_string_storage(): void
+    {
+        new KinstaGroupCacheInvalidator;
+
+        $this->assertFalse(apply_filters('cachetags/store-query-string', true));
+    }
+}


### PR DESCRIPTION
A `group|`-purge Kinsta invalidator, mirroring the Fastly hard/soft pair (base + one override).

### Why
[`kinsta-mu-plugins`](https://github.com/generoi/kinsta-mu-plugins) resolves purge URLs two ways: `single|` (exact URL) and `group|` (string-prefix wildcard — clears the URL and everything beneath it, proven by its `sitemap`/`feed` group entries). A `group|` purge of `/shop/` therefore clears `/shop/`, `/shop/page/2/`, **and** `/shop/?orderby=…` in one request.

### What
- **`KinstaCacheInvalidator`** (base) — unchanged behavior (`single|`, exact), refactored to an overridable `purgeKey()` + a testable `purgeList()`.
- **`KinstaGroupCacheInvalidator`** (new, recommended) — purges by `group|`, and disables `cachetags/store-query-string` so the store keys bare paths. A path prefix-purge already clears every query-string/pagination variant, so per-query store rows aren't needed. The site root (`/`) is always purged `single|`, so a group purge never flushes the whole site (trailing slashes keep `/shop/` from matching `/shopping/`).

### Relationship to #30 / #32
This is the **cleaner fix for the Kinsta fleet**: path-only storage + prefix purge clears all variants, with none of the store-growth that full-URL storage (#32) brings on Kinsta. #32 (full URL + `single|`) remains the tool for exact-match caches that cache query strings (SiteGround, or Kinsta set to cache GET params).

3 dedicated tests; full suite 117 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)