### PR TITLE
Test coverage batch 2: stores, Polylang, WP-Rocket/Debug invalidators

### DIFF
--- a/tests/integration/test-more-invalidators.php
+++ b/tests/integration/test-more-invalidators.php
@@ -1,0 +1,57 @@
+<?php
+
+use Genero\Sage\CacheTags\Invalidators\DebugCacheInvalidator;
+use Genero\Sage\CacheTags\Invalidators\WpRocketCacheInvalidator;
+
+if (! function_exists('rocket_clean_files')) {
+    function rocket_clean_files($urls)
+    {
+        $GLOBALS['__rocket_files'] = $urls;
+
+        return true;
+    }
+}
+if (! function_exists('rocket_clean_domain')) {
+    function rocket_clean_domain()
+    {
+        $GLOBALS['__rocket_domain'] = true;
+    }
+}
+
+/**
+ * @covers \Genero\Sage\CacheTags\Invalidators\WpRocketCacheInvalidator
+ * @covers \Genero\Sage\CacheTags\Invalidators\DebugCacheInvalidator
+ */
+class TestMoreInvalidators extends WP_UnitTestCase
+{
+    public function set_up(): void
+    {
+        parent::set_up();
+        $GLOBALS['__rocket_files'] = null;
+        $GLOBALS['__rocket_domain'] = false;
+    }
+
+    public function test_wprocket_cleans_the_given_urls(): void
+    {
+        $this->assertTrue((new WpRocketCacheInvalidator)->clear(['/a/', '/b/'], ['post:1']));
+        $this->assertSame(['/a/', '/b/'], $GLOBALS['__rocket_files']);
+    }
+
+    public function test_wprocket_skips_the_call_for_no_urls(): void
+    {
+        $this->assertTrue((new WpRocketCacheInvalidator)->clear([], ['post:1']));
+        $this->assertNull($GLOBALS['__rocket_files']);
+    }
+
+    public function test_wprocket_flush_cleans_the_domain(): void
+    {
+        $this->assertTrue((new WpRocketCacheInvalidator)->flush());
+        $this->assertTrue($GLOBALS['__rocket_domain']);
+    }
+
+    public function test_debug_invalidator_always_succeeds(): void
+    {
+        $this->assertTrue((new DebugCacheInvalidator)->clear(['/a/'], ['post:1']));
+        $this->assertTrue((new DebugCacheInvalidator)->flush());
+    }
+}

--- a/tests/integration/test-polylang.php
+++ b/tests/integration/test-polylang.php
@@ -1,0 +1,81 @@
+<?php
+
+use Genero\Sage\CacheTags\Actions\Polylang;
+use Genero\Sage\CacheTags\CacheTags;
+
+// Polylang isn't installed in the test environment — stub the functions the
+// action calls, controllable per-test via globals (default: language inactive).
+if (! function_exists('pll_current_language')) {
+    function pll_current_language()
+    {
+        return $GLOBALS['__pll_lang'] ?? false;
+    }
+}
+if (! function_exists('pll_is_translated_post_type')) {
+    function pll_is_translated_post_type($postType)
+    {
+        return in_array($postType, $GLOBALS['__pll_translated'] ?? [], true);
+    }
+}
+if (! function_exists('pll_get_post_language')) {
+    function pll_get_post_language($id)
+    {
+        return $GLOBALS['__pll_post_lang'] ?? false;
+    }
+}
+
+/**
+ * @covers \Genero\Sage\CacheTags\Actions\Polylang
+ */
+class TestPolylang extends WP_UnitTestCase
+{
+    public function set_up(): void
+    {
+        parent::set_up();
+        $GLOBALS['__pll_lang'] = false;
+        $GLOBALS['__pll_translated'] = [];
+        $GLOBALS['__pll_post_lang'] = false;
+    }
+
+    private function action(): Polylang
+    {
+        return new Polylang(CacheTags::getInstance());
+    }
+
+    public function test_suffixes_translated_archive_tags_with_the_language(): void
+    {
+        $GLOBALS['__pll_lang'] = 'en';
+        $GLOBALS['__pll_translated'] = ['post'];
+
+        $tags = $this->action()->filterArchiveTags(['archive:post', 'post:5']);
+
+        // Archive tag gets the language; the per-post tag is left alone.
+        $this->assertSame(['archive:post:en', 'post:5'], $tags);
+    }
+
+    public function test_passes_tags_through_without_a_language_context(): void
+    {
+        $GLOBALS['__pll_lang'] = false;
+
+        $this->assertSame(['archive:post'], $this->action()->filterArchiveTags(['archive:post']));
+    }
+
+    public function test_only_translated_post_types_are_suffixed(): void
+    {
+        $GLOBALS['__pll_lang'] = 'en';
+        $GLOBALS['__pll_translated'] = ['post']; // 'page' is not translated
+
+        $this->assertSame(['archive:page'], $this->action()->filterArchiveTags(['archive:page']));
+    }
+
+    public function test_status_transition_of_an_untranslated_type_is_a_no_op(): void
+    {
+        $GLOBALS['__pll_lang'] = 'en';
+        $GLOBALS['__pll_translated'] = []; // nothing translated
+        $post = self::factory()->post->create_and_get(['post_status' => 'publish']);
+
+        // Should simply return without error (no language-specific purge).
+        $this->action()->onPostStatusTransition('publish', 'draft', $post);
+        $this->assertTrue(true);
+    }
+}

--- a/tests/integration/test-transient-store.php
+++ b/tests/integration/test-transient-store.php
@@ -1,0 +1,67 @@
+<?php
+
+use Genero\Sage\CacheTags\Stores\CacheTagStore;
+use Genero\Sage\CacheTags\Stores\TransientStore;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Stores\TransientStore
+ * @covers \Genero\Sage\CacheTags\Stores\CacheTagStore
+ */
+class TestTransientStore extends WP_UnitTestCase
+{
+    public function set_up(): void
+    {
+        parent::set_up();
+        delete_option('sage_cache_tags');
+    }
+
+    public function test_saves_and_reads_back_urls_per_tag(): void
+    {
+        $store = new TransientStore;
+        $store->save(['post:1', 'term:2'], '/a/');
+        $store->save(['post:1'], '/b/');
+
+        $this->assertEqualSets(['/a/', '/b/'], $store->get(['post:1']));
+        $this->assertSame(['/a/'], $store->get(['term:2']));
+    }
+
+    public function test_save_dedupes_a_repeated_url(): void
+    {
+        $store = new TransientStore;
+        $store->save(['post:1'], '/a/');
+        $store->save(['post:1'], '/a/');
+
+        $this->assertSame(['/a/'], $store->get(['post:1']));
+    }
+
+    public function test_clear_removes_urls_and_prunes_emptied_tags(): void
+    {
+        $store = new TransientStore;
+        $store->save(['post:1'], '/a/');
+        $store->save(['post:1'], '/b/');
+
+        $store->clear(['/a/'], ['post:1']);
+
+        $this->assertSame(['/b/'], $store->get(['post:1']));
+    }
+
+    public function test_flush_empties_the_store(): void
+    {
+        $store = new TransientStore;
+        $store->save(['post:1'], '/a/');
+
+        $store->flush();
+
+        $this->assertSame([], $store->get(['post:1']));
+    }
+
+    public function test_cachetag_store_is_a_header_only_passthrough(): void
+    {
+        $store = new CacheTagStore;
+
+        $this->assertTrue($store->save(['post:1'], '/a/'));
+        $this->assertSame(['post:1'], $store->get(['post:1']));
+        $this->assertTrue($store->clear([], []));
+        $this->assertTrue($store->flush());
+    }
+}


### PR DESCRIPTION
Second batch toward #18.

- **`TransientStore`** — save/get per tag, URL dedupe, `clear` removing URLs + pruning emptied tags, `flush`.
- **`CacheTagStore`** — the header-only passthrough store (used with Fastly).
- **`Polylang`** — `filterArchiveTags` language-suffixes translated archive tags, passes through without a language context, leaves untranslated types alone; `onPostStatusTransition` is a no-op for untranslated types. Polylang's `pll_*` functions are stubbed (default inactive, controllable per test).
- **`WpRocketCacheInvalidator`** — cleans the given files, skips the call for no URLs, cleans the domain on flush. **`DebugCacheInvalidator`** — clear/flush succeed.

Remaining #18 checkboxes (for a later batch): WP-CLI/Console commands, `Bootstrap`/`CacheTagsServiceProvider` wiring, and the deeper `Core` clear-handler / `CoreTags` branches. Kinsta invalidators were covered when they were added.

136 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)