### PR TITLE
Finish #18 coverage: Core clear handlers, Fastly-soft, ServiceProvider, multisite (+ re-land acorn/env)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
     "laravel/pint": "^1.0",
     "phpunit/phpunit": "^9.6",
     "wp-phpunit/wp-phpunit": "^6.4",
-    "yoast/phpunit-polyfills": "^2.0"
+    "yoast/phpunit-polyfills": "^2.0",
+    "roots/acorn": "^5.0",
+    "wp-cli/wp-cli": "^2.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/src/Actions/Core.php
+++ b/src/Actions/Core.php
@@ -299,7 +299,7 @@ class Core implements Action
         if ($isStatusChanged && ($newStatus === 'publish' || $oldStatus === 'publish')) {
             $taxonomies = array_intersect(
                 CoreTags::getCacheableTaxonomies(),
-                get_post_taxonomies()
+                get_post_taxonomies($post)
             );
 
             // @TODO: Could potentially compare new to old terms and only clear those.

--- a/src/Invalidators/FastlyCacheInvalidator.php
+++ b/src/Invalidators/FastlyCacheInvalidator.php
@@ -13,9 +13,9 @@ class FastlyCacheInvalidator implements Invalidator
 {
     const FASTLY_BASE_URL = 'https://api.fastly.com/service/';
 
-    protected string $serviceId;
+    protected ?string $serviceId;
 
-    protected string $apiKey;
+    protected ?string $apiKey;
 
     public function __construct()
     {

--- a/src/Util.php
+++ b/src/Util.php
@@ -162,15 +162,15 @@ class Util
     /**
      * Get environment variable, using any env() function in scope if available, otherwise getenv().
      */
-    public static function env(string $key): string|false
+    public static function env(string $key): ?string
     {
-        // Check for env() in global namespace
-        if (function_exists('env') && is_callable('env')) {
-            return env($key);
-        }
+        // Prefer a framework env() (e.g. Acorn/Illuminate, which respects .env)
+        // and fall back to getenv(). Both can return non-strings for unset/cast
+        // values (Illuminate null/bool/int, getenv false); normalize those to
+        // null so an unset key is consistently null.
+        $value = function_exists('env') && is_callable('env') ? env($key) : getenv($key);
 
-        // Fallback to getenv()
-        return getenv($key);
+        return is_string($value) ? $value : null;
     }
 
     /**

--- a/tests/integration/test-clear-events.php
+++ b/tests/integration/test-clear-events.php
@@ -132,4 +132,108 @@ class TestClearEvents extends RestTestCase
 
         $this->assertContains("menu:{$menuId}", $this->queuedPurgeTags());
     }
+
+    public function test_publishing_a_post_clears_it_its_archive_and_taxonomies(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'draft']);
+        $this->resetCacheTags();
+
+        wp_update_post(['ID' => $postId, 'post_status' => 'publish']);
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("post:{$postId}", $tags);
+        $this->assertContains('archive:post', $tags);
+        $this->assertContains('archive:post:any', $tags);
+        $this->assertContains('taxonomy:category', $tags);
+    }
+
+    public function test_a_new_approved_comment_clears_its_post(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $commentId = self::factory()->comment->create([
+            'comment_post_ID' => $postId,
+            'comment_approved' => '1',
+        ]);
+        $this->resetCacheTags();
+
+        // comment_post fires on a new comment with its approval status (1 = approved).
+        do_action('comment_post', $commentId, 1, ['comment_post_ID' => $postId]);
+
+        $this->assertContains("post:{$postId}", $this->queuedPurgeTags());
+    }
+
+    public function test_approving_a_comment_clears_it_and_its_post(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $commentId = self::factory()->comment->create([
+            'comment_post_ID' => $postId,
+            'comment_approved' => '0',
+        ]);
+        $this->resetCacheTags();
+
+        wp_set_comment_status($commentId, 'approve');
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("comment:{$commentId}", $tags);
+        $this->assertContains("post:{$postId}", $tags);
+    }
+
+    public function test_editing_an_attachment_clears_it(): void
+    {
+        $attachmentId = self::factory()->post->create(['post_type' => 'attachment']);
+        $this->resetCacheTags();
+
+        do_action('edit_attachment', $attachmentId);
+
+        $this->assertContains("post:{$attachmentId}", $this->queuedPurgeTags());
+    }
+
+    public function test_setting_terms_on_a_post_clears_their_pages_and_the_post(): void
+    {
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        $termId = self::factory()->category->create();
+        $this->resetCacheTags();
+
+        wp_set_object_terms($postId, [$termId], 'category');
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("term:{$termId}:full", $tags);
+        $this->assertContains("post:{$postId}", $tags);
+    }
+
+    public function test_creating_a_user_clears_the_user_and_role(): void
+    {
+        $this->resetCacheTags();
+
+        $userId = self::factory()->user->create(['role' => 'author']);
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("user:{$userId}", $tags);
+        $this->assertContains('role:author', $tags);
+    }
+
+    public function test_updating_a_user_clears_the_user_and_role(): void
+    {
+        $userId = self::factory()->user->create(['role' => 'author']);
+        $this->resetCacheTags();
+
+        wp_update_user(['ID' => $userId, 'display_name' => 'Renamed']);
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("user:{$userId}", $tags);
+        $this->assertContains('role:author', $tags);
+    }
+
+    public function test_deleting_a_user_clears_the_user_and_role(): void
+    {
+        require_once ABSPATH.'wp-admin/includes/user.php';
+        $userId = self::factory()->user->create(['role' => 'author']);
+        $this->resetCacheTags();
+
+        wp_delete_user($userId);
+
+        $tags = $this->queuedPurgeTags();
+        $this->assertContains("user:{$userId}", $tags);
+        $this->assertContains('role:author', $tags);
+    }
 }

--- a/tests/integration/test-console-commands.php
+++ b/tests/integration/test-console-commands.php
@@ -1,0 +1,95 @@
+<?php
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Console\ClearCommand;
+use Genero\Sage\CacheTags\Console\DatabaseCommand;
+use Genero\Sage\CacheTags\Console\FlushCommand;
+use Genero\Sage\CacheTags\Invalidators\DebugCacheInvalidator;
+use Genero\Sage\CacheTags\Stores\CacheTagStore;
+use Illuminate\Console\Command;
+use Illuminate\Container\Container;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Real integration against Acorn's (Illuminate) console — the commands run
+ * through Command::run(), resolving CacheTags from a real container and writing
+ * to a real output buffer.
+ *
+ * @covers \Genero\Sage\CacheTags\Console\FlushCommand
+ * @covers \Genero\Sage\CacheTags\Console\ClearCommand
+ * @covers \Genero\Sage\CacheTags\Console\DatabaseCommand
+ */
+class TestConsoleCommands extends WP_UnitTestCase
+{
+    private ?CacheTags $saved;
+
+    private Container $container;
+
+    public function set_up(): void
+    {
+        parent::set_up();
+        $this->saved = $this->prop()->getValue();
+        $this->prop()->setValue(null, null);
+
+        $cacheTags = CacheTags::make(new CacheTagStore, false, 'Cache-Tag', [new DebugCacheInvalidator]);
+        // Illuminate's Command::run() calls $laravel->runningUnitTests(); the plain
+        // container doesn't have it, so extend it (Acorn's Application would in a
+        // real boot).
+        $this->container = new class extends Container
+        {
+            public function runningUnitTests(): bool
+            {
+                return true;
+            }
+        };
+        $this->container->instance(CacheTags::class, $cacheTags);
+    }
+
+    public function tear_down(): void
+    {
+        $this->prop()->setValue(null, $this->saved);
+        parent::tear_down();
+    }
+
+    private function prop(): ReflectionProperty
+    {
+        $prop = new ReflectionProperty(CacheTags::class, 'instance');
+        $prop->setAccessible(true);
+
+        return $prop;
+    }
+
+    private function runCommand(Command $command, array $input = []): array
+    {
+        $command->setLaravel($this->container);
+        $output = new BufferedOutput;
+        $exitCode = $command->run(new ArrayInput($input), $output);
+
+        return [$exitCode, $output->fetch()];
+    }
+
+    public function test_flush_command_flushes_and_reports(): void
+    {
+        [$exitCode, $output] = $this->runCommand(new FlushCommand);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Flushed caches', $output);
+    }
+
+    public function test_clear_command_parses_the_tags_argument_and_clears(): void
+    {
+        [$exitCode, $output] = $this->runCommand(new ClearCommand, ['tags' => 'post:1']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Cleared cache tags', $output);
+    }
+
+    public function test_database_command_creates_the_table(): void
+    {
+        [$exitCode, $output] = $this->runCommand(new DatabaseCommand);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Created table', $output);
+    }
+}

--- a/tests/integration/test-database.php
+++ b/tests/integration/test-database.php
@@ -39,6 +39,23 @@ class TestDatabase extends WP_UnitTestCase
         $this->assertSame(2, (int) get_option('cachetags_db_version'));
     }
 
+    public function test_creates_the_table_for_a_new_multisite_subsite(): void
+    {
+        if (! is_multisite()) {
+            $this->markTestSkipped('Requires multisite (run with the multisite config).');
+        }
+
+        global $wpdb;
+        $blogId = self::factory()->blog->create();
+
+        switch_to_blog($blogId);
+        $table = "{$wpdb->prefix}cache_tags";
+        $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+        restore_current_blog();
+
+        $this->assertSame($table, $exists, 'wp_initialize_site provisions the new site table');
+    }
+
     private function migrator(): object
     {
         return new class

--- a/tests/integration/test-fastly-invalidator.php
+++ b/tests/integration/test-fastly-invalidator.php
@@ -1,9 +1,11 @@
 <?php
 
 use Genero\Sage\CacheTags\Invalidators\FastlyCacheInvalidator;
+use Genero\Sage\CacheTags\Invalidators\FastlySoftCacheInvalidator;
 
 /**
  * @covers \Genero\Sage\CacheTags\Invalidators\FastlyCacheInvalidator
+ * @covers \Genero\Sage\CacheTags\Invalidators\FastlySoftCacheInvalidator
  */
 class TestFastlyInvalidator extends WP_UnitTestCase
 {
@@ -46,5 +48,13 @@ class TestFastlyInvalidator extends WP_UnitTestCase
         add_filter('pre_http_request', fn () => ['response' => ['code' => 403], 'body' => '{"msg":"nope"}']);
 
         $this->assertFalse((new FastlyCacheInvalidator)->clear(['/a/'], ['post:1']));
+    }
+
+    public function test_soft_invalidator_sends_the_soft_purge_header(): void
+    {
+        (new FastlySoftCacheInvalidator)->clear(['/a/'], ['post:1']);
+
+        $this->assertCount(1, $this->requests);
+        $this->assertSame('1', $this->requests[0]['args']['headers']['fastly-soft-purge'] ?? null);
     }
 }

--- a/tests/integration/test-service-provider.php
+++ b/tests/integration/test-service-provider.php
@@ -1,0 +1,61 @@
+<?php
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\CacheTagsServiceProvider;
+use Genero\Sage\CacheTags\Invalidators\DebugCacheInvalidator;
+use Genero\Sage\CacheTags\Stores\TransientStore;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+
+/**
+ * The Acorn service provider wires CacheTags from config, mirroring the
+ * standalone Bootstrap.
+ *
+ * @covers \Genero\Sage\CacheTags\CacheTagsServiceProvider
+ */
+class TestServiceProvider extends WP_UnitTestCase
+{
+    private ?CacheTags $saved;
+
+    public function set_up(): void
+    {
+        parent::set_up();
+        if (! class_exists(Container::class)) {
+            $this->markTestSkipped('Acorn/Illuminate is not installed in this environment.');
+        }
+        $this->saved = $this->prop()->getValue();
+        $this->prop()->setValue(null, null);
+    }
+
+    public function tear_down(): void
+    {
+        $this->prop()->setValue(null, $this->saved);
+        parent::tear_down();
+    }
+
+    private function prop(): ReflectionProperty
+    {
+        $prop = new ReflectionProperty(CacheTags::class, 'instance');
+        $prop->setAccessible(true);
+
+        return $prop;
+    }
+
+    public function test_register_builds_cachetags_from_config(): void
+    {
+        $app = new Container;
+        $app->instance('config', new Repository(['cachetags' => [
+            'store' => TransientStore::class,
+            'invalidator' => [DebugCacheInvalidator::class],
+            'action' => [],
+            'disable' => true,
+        ]]));
+
+        (new CacheTagsServiceProvider($app))->register();
+
+        $cacheTags = $app->make(CacheTags::class);
+        $this->assertInstanceOf(CacheTags::class, $cacheTags);
+        $this->assertInstanceOf(TransientStore::class, $cacheTags->store);
+        $this->assertCount(1, $cacheTags->invalidators);
+    }
+}

--- a/tests/integration/test-wpcli-commands.php
+++ b/tests/integration/test-wpcli-commands.php
@@ -7,37 +7,10 @@ use Genero\Sage\CacheTags\WpCli\ClearCommand;
 use Genero\Sage\CacheTags\WpCli\DatabaseCommand;
 use Genero\Sage\CacheTags\WpCli\FlushCommand;
 
-// The commands extend WP_CLI_Command and call WP_CLI:: statics, neither of which
-// is loaded in the phpunit context. Stub the class (but NOT the WP_CLI constant,
-// so nothing else thinks it's running under WP-CLI). error() throws so the
-// failure path is observable.
-if (! class_exists('WP_CLI_Command')) {
-    class WP_CLI_Command {}
-}
-if (! class_exists('WP_CLI')) {
-    class WP_CLI
-    {
-        public static function success($message)
-        {
-            $GLOBALS['__wpcli'][] = "success:$message";
-        }
-
-        public static function error($message)
-        {
-            $GLOBALS['__wpcli'][] = "error:$message";
-            throw new RuntimeException($message);
-        }
-
-        public static function log($message)
-        {
-            $GLOBALS['__wpcli'][] = "log:$message";
-        }
-
-        public static function add_command($name, $command) {}
-    }
-}
-
 /**
+ * Real integration against WP-CLI: the commands extend the real WP_CLI_Command
+ * and call the real WP_CLI:: statics, routed through a capturing logger.
+ *
  * @covers \Genero\Sage\CacheTags\WpCli\FlushCommand
  * @covers \Genero\Sage\CacheTags\WpCli\ClearCommand
  * @covers \Genero\Sage\CacheTags\WpCli\DatabaseCommand
@@ -46,13 +19,47 @@ class TestWpCliCommands extends WP_UnitTestCase
 {
     private ?CacheTags $saved;
 
+    private object $logger;
+
     public function set_up(): void
     {
         parent::set_up();
-        $GLOBALS['__wpcli'] = [];
         $this->saved = $this->prop()->getValue();
         $this->prop()->setValue(null, null);
         CacheTags::make(new CacheTagStore, false, 'Cache-Tag', [new DebugCacheInvalidator]);
+
+        $this->logger = new class
+        {
+            public array $messages = [];
+
+            public function info($message)
+            {
+                $this->messages[] = "info:$message";
+            }
+
+            public function success($message)
+            {
+                $this->messages[] = "success:$message";
+            }
+
+            public function warning($message)
+            {
+                $this->messages[] = "warning:$message";
+            }
+
+            public function error($message)
+            {
+                $this->messages[] = "error:$message";
+                throw new RuntimeException($message);
+            }
+
+            public function debug($message, $group = false) {}
+
+            public function line($message = '') {}
+
+            public function error_multi_line($message_lines) {}
+        };
+        WP_CLI::set_logger($this->logger);
     }
 
     public function tear_down(): void
@@ -73,20 +80,20 @@ class TestWpCliCommands extends WP_UnitTestCase
     {
         (new FlushCommand)();
 
-        $this->assertSame(['success:Flushed caches'], $GLOBALS['__wpcli']);
+        $this->assertContains('success:Flushed caches', $this->logger->messages);
     }
 
     public function test_clear_command_reports_success(): void
     {
         (new ClearCommand)(['post:1']);
 
-        $this->assertSame(['success:Cleared cache tags'], $GLOBALS['__wpcli']);
+        $this->assertContains('success:Cleared cache tags', $this->logger->messages);
     }
 
     public function test_database_command_creates_the_table(): void
     {
         (new DatabaseCommand)();
 
-        $this->assertSame(['success:Created table'], $GLOBALS['__wpcli']);
+        $this->assertContains('success:Created table', $this->logger->messages);
     }
 }

--- a/tests/unit/test-util.php
+++ b/tests/unit/test-util.php
@@ -28,7 +28,7 @@ class TestUtil extends WP_UnitTestCase
         putenv('CACHETAGS_TEST_ENV=present');
 
         $this->assertSame('present', Util::env('CACHETAGS_TEST_ENV'));
-        $this->assertFalse(Util::env('CACHETAGS_TEST_MISSING'));
+        $this->assertNull(Util::env('CACHETAGS_TEST_MISSING'));
 
         putenv('CACHETAGS_TEST_ENV');
     }


### PR DESCRIPTION
Closes #18 — completes the pre-existing-codebase coverage.

### New coverage
- **`Core` clear handlers** — publishing a post (status transition + taxonomy pages), new approved comment, approving a comment, editing an attachment, setting object terms, and user create/update/delete (only role-change was covered before).
- **Fastly *soft* invalidator** — sends the `fastly-soft-purge` header.
- **`CacheTagsServiceProvider`** — `register()` builds CacheTags from the Acorn config (real Illuminate container + `Repository`), mirroring `Bootstrap`.
- **Multisite** — `createTableForNewSite` provisions the table on a new subsite (skip-guarded; runs under the multisite config).

### Bug fix surfaced
`Core::onPostStatusTransition` called `get_post_taxonomies()` with **no argument** — relying on the global `$post`, which isn't the transitioning post during the hook, so the taxonomy pages weren't reliably cleared on publish. Now passes `$post`.

### Re-lands the orphaned #38 tail
PR #38 was merged early (Bootstrap/CoreTags/WP-CLI-stubs); my follow-up commits never made it to master. This brings them back: **`roots/acorn` + `wp-cli/wp-cli` dev-deps**, the **real** WP-CLI + Acorn Console command tests (vs stubs), the **`Util::env()` `string|false` → `?string`** fix (illuminate's `env()` returns null on Sage sites → would fatal `FastlyCacheInvalidator`), and nullable Fastly properties.

164 tests (1 multisite skip in single-site). FacetWP/WPML/Gravity Forms stay stubbed (premium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)