### PR TITLE
Test the Acorn integration traits (real Blade) + re-land pcov/HttpHeader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,10 @@ jobs:
       - name: Start wp-env
         run: npx @wordpress/env@latest start
 
-      - name: Run tests
-        run: npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags ./vendor/bin/phpunit
+      # The tests run inside the wp-env container, so the coverage driver has to
+      # live there (setup-php's driver is on the runner, not the container).
+      - name: Enable coverage driver (pcov)
+        run: docker exec -u root "$(docker ps -qf name=tests-cli)" sh -c "pecl install pcov && docker-php-ext-enable pcov"
+
+      - name: Run tests with coverage
+        run: npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags ./vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "lint:fix": "vendor/bin/pint",
     "test:unit": "vendor/bin/phpunit --testsuite unit",
     "test:integration": "vendor/bin/phpunit --testsuite integration",
+    "test:coverage": "vendor/bin/phpunit --coverage-text",
     "test": "vendor/bin/phpunit"
   },
   "archive": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,12 @@
     </testsuite>
   </testsuites>
 
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </coverage>
+
   <php>
     <env name="WP_PHPUNIT__TESTS_CONFIG" value="/var/www/html/wp-config.php" />
   </php>

--- a/src/Actions/HttpHeader.php
+++ b/src/Actions/HttpHeader.php
@@ -35,8 +35,18 @@ class HttpHeader implements Action
         $header = $this->cacheTags->httpHeader;
 
         if ($header && ! empty($tags)) {
-            header(sprintf('%s: %s', $header, implode(' ', $tags)));
+            $this->emit($header, implode(' ', $tags));
         }
+    }
+
+    /**
+     * Send the response header. Runs late (wp_footer, after tags are collected,
+     * with output buffered in bind()), so it uses header() directly; isolated
+     * here so the surrounding gating/building can be tested without it.
+     */
+    protected function emit(string $header, string $value): void
+    {
+        header(sprintf('%s: %s', $header, $value));
     }
 
     /**

--- a/tests/fixtures/views/cachetag-composer.blade.php
+++ b/tests/fixtures/views/cachetag-composer.blade.php
@@ -1,0 +1,3 @@
+<article>
+  <h1>{{ $heading }}</h1>
+</article>

--- a/tests/integration/test-acorn-traits.php
+++ b/tests/integration/test-acorn-traits.php
@@ -1,0 +1,155 @@
+<?php
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Concerns\BlockCacheTags;
+use Genero\Sage\CacheTags\Concerns\ComposerCacheTags;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\Engines\CompilerEngine;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Engines\PhpEngine;
+use Illuminate\View\Factory;
+use Illuminate\View\FileViewFinder;
+use Roots\Acorn\View\Composer;
+
+// Roots\app() delegates to the global app() helper, which a real Acorn/Laravel
+// boot provides. Define the standard resolver so the traits run as they would
+// in production.
+if (! function_exists('app')) {
+    function app($abstract = null, array $parameters = [])
+    {
+        $container = Container::getInstance();
+
+        return is_null($abstract) ? $container : $container->make($abstract, $parameters);
+    }
+}
+
+/**
+ * A Sage view composer using ComposerCacheTags: when its Blade view is composed,
+ * its cache tags are registered.
+ */
+class CacheTagComposerFixture extends Composer
+{
+    use ComposerCacheTags;
+
+    protected static $views = ['cachetag-composer'];
+
+    public function cacheTags(ViewContract $view): array
+    {
+        return ['post:42', 'term:7'];
+    }
+}
+
+/**
+ * Stand-in for the AcfComposer Block base (Log1x\AcfComposer\Block isn't a
+ * dependency); BlockCacheTags only relies on a parent view($view, $with).
+ */
+abstract class FakeAcfBlockBase
+{
+    public function view($view, $with = [])
+    {
+        return ['view' => $view, 'with' => $with];
+    }
+}
+
+class CacheTagBlockFixture extends FakeAcfBlockBase
+{
+    use BlockCacheTags;
+
+    public function cacheTags(): array
+    {
+        return ['post:99'];
+    }
+}
+
+/**
+ * The Acorn integration traits add cache tags through the real Illuminate view /
+ * Blade pipeline (ComposerCacheTags) and the block render path (BlockCacheTags).
+ *
+ * @covers \Genero\Sage\CacheTags\Concerns\ComposerCacheTags
+ * @covers \Genero\Sage\CacheTags\Concerns\BlockCacheTags
+ */
+class TestAcornTraits extends WP_UnitTestCase
+{
+    private $previousContainer;
+
+    public function set_up(): void
+    {
+        parent::set_up();
+        if (! class_exists(Factory::class) || ! class_exists(Composer::class)) {
+            $this->markTestSkipped('Acorn / Illuminate view is not installed.');
+        }
+        $this->previousContainer = Container::getInstance();
+    }
+
+    public function tear_down(): void
+    {
+        Container::setInstance($this->previousContainer);
+        parent::tear_down();
+    }
+
+    /**
+     * Reset the shared CacheTags buffer and bind it so Roots\app(CacheTags::class)
+     * (i.e. the global app() container) resolves to it.
+     */
+    private function bindCacheTags(): CacheTags
+    {
+        $cacheTags = CacheTags::getInstance();
+        $ref = new ReflectionProperty($cacheTags, 'cacheTags');
+        $ref->setAccessible(true);
+        $ref->setValue($cacheTags, []);
+
+        $container = new Container;
+        $container->instance(CacheTags::class, $cacheTags);
+        Container::setInstance($container);
+
+        return $cacheTags;
+    }
+
+    private function viewFactory(Container $container): Factory
+    {
+        $files = new Filesystem;
+        $compiled = get_temp_dir().'cachetag-blade-compiled';
+        if (! is_dir($compiled)) {
+            mkdir($compiled, 0777, true);
+        }
+
+        $compiler = new BladeCompiler($files, $compiled);
+        $resolver = new EngineResolver;
+        $resolver->register('blade', fn () => new CompilerEngine($compiler, $files));
+        $resolver->register('php', fn () => new PhpEngine($files));
+
+        $finder = new FileViewFinder($files, [dirname(__DIR__).'/fixtures/views']);
+        $factory = new Factory($resolver, $finder, new Dispatcher($container));
+        $factory->setContainer($container);
+
+        return $factory;
+    }
+
+    public function test_composer_trait_tags_when_its_blade_view_renders(): void
+    {
+        $cacheTags = $this->bindCacheTags();
+        $container = Container::getInstance();
+        $factory = $this->viewFactory($container);
+        $factory->composer('cachetag-composer', CacheTagComposerFixture::class);
+
+        $html = $factory->make('cachetag-composer', ['heading' => 'Cached page'])->render();
+
+        $this->assertStringContainsString('Cached page', $html, 'the Blade view actually rendered');
+        $this->assertContains('post:42', $cacheTags->get());
+        $this->assertContains('term:7', $cacheTags->get());
+    }
+
+    public function test_block_trait_tags_and_delegates_to_the_parent_renderer(): void
+    {
+        $cacheTags = $this->bindCacheTags();
+
+        $result = (new CacheTagBlockFixture)->view('blocks.test', ['foo' => 'bar']);
+
+        $this->assertSame(['view' => 'blocks.test', 'with' => ['foo' => 'bar']], $result, 'parent::view ran');
+        $this->assertContains('post:99', $cacheTags->get());
+    }
+}

--- a/tests/integration/test-http-header.php
+++ b/tests/integration/test-http-header.php
@@ -59,4 +59,48 @@ class TestHttpHeader extends WP_UnitTestCase
     {
         $this->assertSame('passthrough', $this->action()->restPostDispatch('passthrough'));
     }
+
+    private function capturingAction(): HttpHeader
+    {
+        return new class(CacheTags::getInstance()) extends HttpHeader
+        {
+            public array $emitted = [];
+
+            protected function emit(string $header, string $value): void
+            {
+                $this->emitted[] = "{$header}: {$value}";
+            }
+        };
+    }
+
+    public function test_front_end_emits_the_header_on_a_cacheable_request(): void
+    {
+        $this->resetTags()->add(['post:1']);
+        $action = $this->capturingAction();
+
+        $action->addHttpHeader();
+
+        $this->assertSame(['Cache-Tag: post:1'], $action->emitted);
+    }
+
+    public function test_front_end_skips_a_non_cacheable_request(): void
+    {
+        $this->resetTags()->add(['post:1']);
+        add_filter('cachetags/cacheable', '__return_false');
+        $action = $this->capturingAction();
+
+        $action->addHttpHeader();
+
+        $this->assertSame([], $action->emitted);
+    }
+
+    public function test_front_end_skips_when_there_are_no_tags(): void
+    {
+        $this->resetTags();
+        $action = $this->capturingAction();
+
+        $action->addHttpHeader();
+
+        $this->assertSame([], $action->emitted);
+    }
 }


### PR DESCRIPTION
### Acorn integration traits — now covered
These were previously flagged as "not unit-testable here." They are, with the real Illuminate view stack (a dev dependency via Acorn):

- **`ComposerCacheTags`** — builds a real `Illuminate\View\Factory` (Blade compiler engine + file finder + event dispatcher), registers a Sage `Composer` using the trait, and **renders an actual `.blade.php` fixture**. When the view composes, the trait's `compose()` → `Roots\app(CacheTags::class)->add(...)` runs, and the tags are asserted on `CacheTags`.
- **`BlockCacheTags`** — Log1x's AcfComposer `Block` base isn't a dependency (and a full ACF block render needs ACF + the theme), so the trait runs over a minimal stand-in base. It verifies the trait delegates to `parent::view()` and then registers its tags.

`Roots\app()` delegates to the global `app()` helper that a real Acorn/Laravel boot provides; the test defines the standard resolver so the traits behave exactly as in production.

### Also: re-lands the orphaned pcov/HttpHeader work
The tail commit of #41 (HttpHeader `emit()` seam + the pcov coverage tooling — `<coverage>` config, `composer test:coverage`, the CI step) didn't make it into the merge. This branch cherry-picks it back, so merging this restores that too.

179 tests (1 multisite skip). Coverage ~69.9% lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)