### PR TITLE
Test coverage batch 6: tag vocabulary, CacheTags orchestration, invalidator branches

### DIFF
--- a/tests/integration/test-cache-tags-core.php
+++ b/tests/integration/test-cache-tags-core.php
@@ -1,0 +1,214 @@
+<?php
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\Contracts\Invalidator;
+use Genero\Sage\CacheTags\Contracts\Store;
+
+class RecordingStore implements Store
+{
+    public array $saved = [];
+
+    public array $cleared = [];
+
+    public bool $flushed = false;
+
+    public bool $clearResult = true;
+
+    public bool $flushResult = true;
+
+    public array $urlsFor = [];
+
+    public function save(array $tags, string $url): bool
+    {
+        $this->saved[] = [$url, $tags];
+
+        return true;
+    }
+
+    public function get(array $tags): array
+    {
+        return $this->urlsFor;
+    }
+
+    public function clear(array $urls, array $tags): bool
+    {
+        $this->cleared[] = [$urls, $tags];
+
+        return $this->clearResult;
+    }
+
+    public function flush(): bool
+    {
+        $this->flushed = true;
+
+        return $this->flushResult;
+    }
+}
+
+class RecordingInvalidator implements Invalidator
+{
+    public array $clearedWith = [];
+
+    public bool $flushed = false;
+
+    public bool $clearResult = true;
+
+    public bool $flushResult = true;
+
+    public function clear(array $urls, array $tags): bool
+    {
+        $this->clearedWith[] = [$urls, $tags];
+
+        return $this->clearResult;
+    }
+
+    public function flush(): bool
+    {
+        $this->flushed = true;
+
+        return $this->flushResult;
+    }
+}
+
+class RecordingAction implements Action
+{
+    public bool $bound = false;
+
+    public function bind(): void
+    {
+        $this->bound = true;
+    }
+}
+
+/**
+ * The orchestration in CacheTags: save gating, and the invalidator-then-store
+ * ordering for purge/flush (store is only touched when invalidators succeed).
+ *
+ * @covers \Genero\Sage\CacheTags\CacheTags
+ */
+class TestCacheTagsCore extends WP_UnitTestCase
+{
+    private $savedInstance;
+
+    private bool $swapped = false;
+
+    public function tear_down(): void
+    {
+        if ($this->swapped) {
+            $this->instanceProp()->setValue(null, $this->savedInstance);
+            $this->swapped = false;
+        }
+        parent::tear_down();
+    }
+
+    private function instanceProp(): ReflectionProperty
+    {
+        $prop = new ReflectionProperty(CacheTags::class, 'instance');
+        $prop->setAccessible(true);
+
+        return $prop;
+    }
+
+    private function make(Store $store, array $invalidators): CacheTags
+    {
+        $prop = $this->instanceProp();
+        $this->savedInstance = $prop->getValue();
+        $this->swapped = true;
+        $prop->setValue(null, null);
+
+        return CacheTags::make($store, false, 'Cache-Tag', $invalidators);
+    }
+
+    public function test_purge_queued_runs_invalidators_then_clears_the_store(): void
+    {
+        $store = new RecordingStore;
+        $store->urlsFor = ['https://example.com/a/'];
+        $invalidator = new RecordingInvalidator;
+        $cacheTags = $this->make($store, [$invalidator]);
+
+        $cacheTags->clear(['post:1']);
+
+        $this->assertTrue($cacheTags->purgeQueued());
+        $this->assertSame([[['https://example.com/a/'], ['post:1']]], $invalidator->clearedWith);
+        $this->assertNotEmpty($store->cleared, 'store cleared after success');
+    }
+
+    public function test_purge_queued_does_not_clear_the_store_when_an_invalidator_fails(): void
+    {
+        $store = new RecordingStore;
+        $store->urlsFor = ['https://example.com/a/'];
+        $invalidator = new RecordingInvalidator;
+        $invalidator->clearResult = false;
+        $cacheTags = $this->make($store, [$invalidator]);
+
+        $cacheTags->clear(['post:1']);
+
+        $this->assertFalse($cacheTags->purgeQueued());
+        $this->assertEmpty($store->cleared, 'store left intact when a purge fails');
+    }
+
+    public function test_purge_queued_is_a_noop_without_tags_or_urls(): void
+    {
+        $store = new RecordingStore;
+        $invalidator = new RecordingInvalidator;
+        $cacheTags = $this->make($store, [$invalidator]);
+
+        $this->assertTrue($cacheTags->purgeQueued(), 'no queued tags');
+        $this->assertEmpty($invalidator->clearedWith);
+
+        $cacheTags->clear(['post:1']);
+        $store->urlsFor = [];
+        $this->assertTrue($cacheTags->purgeQueued(), 'no matching urls');
+        $this->assertEmpty($invalidator->clearedWith);
+    }
+
+    public function test_flush_runs_invalidators_then_the_store(): void
+    {
+        $store = new RecordingStore;
+        $invalidator = new RecordingInvalidator;
+        $cacheTags = $this->make($store, [$invalidator]);
+
+        $this->assertTrue($cacheTags->flush());
+        $this->assertTrue($invalidator->flushed);
+        $this->assertTrue($store->flushed);
+    }
+
+    public function test_flush_does_not_flush_the_store_when_an_invalidator_fails(): void
+    {
+        $store = new RecordingStore;
+        $invalidator = new RecordingInvalidator;
+        $invalidator->flushResult = false;
+        $cacheTags = $this->make($store, [$invalidator]);
+
+        $this->assertFalse($cacheTags->flush());
+        $this->assertFalse($store->flushed, 'store not flushed when a flush fails');
+    }
+
+    public function test_save_stores_tags_for_a_front_end_url_but_skips_admin(): void
+    {
+        $store = new RecordingStore;
+        $cacheTags = $this->make($store, []);
+
+        $cacheTags->add(['post:1']);
+        $cacheTags->save('https://example.com/page/');
+        $this->assertSame('https://example.com/page/', $store->saved[0][0] ?? null);
+
+        $store->saved = [];
+        $cacheTags->save(admin_url('edit.php'));
+        $this->assertEmpty($store->saved, 'admin urls are not stored');
+    }
+
+    public function test_bind_action_tracks_it_for_has_action(): void
+    {
+        $cacheTags = $this->make(new RecordingStore, []);
+        $action = new RecordingAction;
+
+        $cacheTags->bindAction($action);
+
+        $this->assertTrue($action->bound, 'bind() was called');
+        $this->assertTrue($cacheTags->hasAction($action));
+        $this->assertTrue($cacheTags->hasAction(RecordingAction::class));
+        $this->assertFalse($cacheTags->hasAction('No\\Such\\Action'));
+    }
+}

--- a/tests/integration/test-kinsta-invalidators.php
+++ b/tests/integration/test-kinsta-invalidators.php
@@ -42,4 +42,64 @@ class TestKinstaInvalidators extends WP_UnitTestCase
 
         $this->assertFalse(apply_filters('cachetags/store-query-string', true));
     }
+
+    public function test_clear_posts_the_purge_list_to_the_immediate_endpoint(): void
+    {
+        $invalidator = new class extends KinstaCacheInvalidator
+        {
+            public array $posts = [];
+
+            protected function post(string $endpoint, string $body): bool
+            {
+                $this->posts[] = [$endpoint, $body];
+
+                return true;
+            }
+        };
+
+        $this->assertTrue($invalidator->clear($this->urls, ['post:1']));
+        $this->assertCount(1, $invalidator->posts, 'small purge fits one request');
+        $this->assertSame(KinstaCacheInvalidator::IMMEDIATE_PATH, $invalidator->posts[0][0]);
+        $this->assertStringContainsString('example.com', urldecode($invalidator->posts[0][1]));
+    }
+
+    public function test_clear_bulk_flushes_when_it_would_take_more_than_three_requests(): void
+    {
+        $invalidator = new class extends KinstaCacheInvalidator
+        {
+            public bool $flushed = false;
+
+            public int $postCount = 0;
+
+            protected function post(string $endpoint, string $body): bool
+            {
+                $this->postCount++;
+
+                return true;
+            }
+
+            public function flush(): bool
+            {
+                $this->flushed = true;
+
+                return true;
+            }
+        };
+
+        $urls = [];
+        for ($i = 0; $i < 6000; $i++) {
+            $urls["key{$i}"] = "https://example.com/some/longer/path/number-{$i}/";
+        }
+
+        $this->assertTrue($invalidator->clear($urls, ['post:1']));
+        $this->assertTrue($invalidator->flushed, 'over three chunks → single bulk flush');
+        $this->assertSame(0, $invalidator->postCount, 'individual posts skipped');
+    }
+
+    public function test_flush_calls_the_clear_all_endpoint(): void
+    {
+        add_filter('pre_http_request', fn () => ['response' => ['code' => 200], 'body' => '']);
+
+        $this->assertTrue((new KinstaCacheInvalidator)->flush());
+    }
 }

--- a/tests/integration/test-nonce-cron.php
+++ b/tests/integration/test-nonce-cron.php
@@ -1,5 +1,6 @@
 <?php
 
+use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\NonceCron;
 
 /**
@@ -23,6 +24,18 @@ class TestNonceCron extends WP_UnitTestCase
 
         NonceCron::schedule();
         $this->assertSame($first, wp_next_scheduled(NonceCron::HOOK), 'does not double-schedule');
+    }
+
+    public function test_purge_queues_the_nonce_tag_and_runs_the_queue(): void
+    {
+        $cacheTags = CacheTags::getInstance();
+        $prop = new ReflectionProperty($cacheTags, 'purgeTags');
+        $prop->setAccessible(true);
+        $prop->setValue($cacheTags, []);
+
+        NonceCron::purge();
+
+        $this->assertContains('nonce', $prop->getValue($cacheTags));
     }
 
     public function test_unschedule_clears_the_event(): void

--- a/tests/integration/test-polylang.php
+++ b/tests/integration/test-polylang.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Actions\Polylang;
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tags\PolylangTags;
 
 /**
  * Real integration against an installed Polylang: the action's language tagging
@@ -68,5 +69,25 @@ class TestPolylang extends WP_UnitTestCase
         PLL()->curlang = null;
 
         $this->assertSame(['archive:post'], $this->action()->filterArchiveTags(['archive:post']));
+    }
+
+    public function test_tags_helper_returns_the_current_language(): void
+    {
+        $this->assertSame(['lang:en'], PolylangTags::language());
+    }
+
+    public function test_tags_helper_builds_a_per_language_archive(): void
+    {
+        $model = PLL()->model;
+        if (! $model->get_language('fi')) {
+            $model->add_language(['name' => 'Finnish', 'slug' => 'fi', 'locale' => 'fi', 'rtl' => 0, 'term_group' => 1, 'flag' => 'fi']);
+            $model->clean_languages_cache();
+        }
+
+        $tags = PolylangTags::archiveAllLanguages('post');
+
+        // 'post' is translated, so it expands to one archive tag per language.
+        $this->assertContains('archive:post:en', $tags);
+        $this->assertContains('archive:post:fi', $tags);
     }
 }

--- a/tests/integration/test-tags.php
+++ b/tests/integration/test-tags.php
@@ -1,0 +1,60 @@
+<?php
+
+use Genero\Sage\CacheTags\Tags\GravityformTags;
+use Genero\Sage\CacheTags\Tags\SiteTags;
+use Genero\Sage\CacheTags\Tags\WooCommerceTags;
+
+/**
+ * The tag "vocabulary" classes — the strings these build are what gets purged,
+ * so the per-shape branches matter.
+ *
+ * @covers \Genero\Sage\CacheTags\Tags\GravityformTags
+ * @covers \Genero\Sage\CacheTags\Tags\SiteTags
+ * @covers \Genero\Sage\CacheTags\Tags\WooCommerceTags
+ */
+class TestTags extends WP_UnitTestCase
+{
+    public function test_gravityform_forms_from_id_object_array_and_null(): void
+    {
+        $this->assertSame(['gform:5'], GravityformTags::forms(5));
+        $this->assertSame(['gform:5'], GravityformTags::forms(['id' => 5]));
+        $this->assertSame(['gform:1', 'gform:2'], GravityformTags::forms([1, 2]));
+        $this->assertSame([], GravityformTags::forms(null));
+    }
+
+    public function test_site_tags_for_current_explicit_and_unhandled_input(): void
+    {
+        $current = get_current_blog_id();
+
+        $this->assertSame(["site:{$current}"], SiteTags::sites(), 'null → current site');
+        $this->assertSame(['site:7'], SiteTags::sites(7));
+        $this->assertSame(['site:3', 'site:4'], SiteTags::sites([3, 4]));
+        // 'any' on a single-site install is just the current site.
+        $this->assertSame(["site:{$current}"], SiteTags::sites('any'));
+        $this->assertSame([], SiteTags::sites(new stdClass));
+    }
+
+    public function test_woocommerce_products_from_id_array_post_and_null(): void
+    {
+        $this->assertSame(['post:10'], WooCommerceTags::products(10));
+        $this->assertSame(['post:10', 'post:11'], WooCommerceTags::products([10, 11]));
+        $this->assertSame([], WooCommerceTags::products(null));
+
+        $post = self::factory()->post->create_and_get();
+        $this->assertSame(["post:{$post->ID}"], WooCommerceTags::products($post));
+    }
+
+    public function test_woocommerce_shop_tag_with_and_without_a_shop_page(): void
+    {
+        if (! function_exists('wc_get_page_id')) {
+            $this->markTestSkipped('WooCommerce is not installed.');
+        }
+
+        $shopId = self::factory()->post->create();
+        update_option('woocommerce_shop_page_id', $shopId);
+        $this->assertSame(["post:{$shopId}"], WooCommerceTags::shop());
+
+        delete_option('woocommerce_shop_page_id');
+        $this->assertSame([], WooCommerceTags::shop(), 'no shop page → no tag');
+    }
+}


### PR DESCRIPTION
Targets the lowest-coverage, most bug-prone branches from a per-file coverage pass. **Lines 69.9% → 76.8%**, 196 tests.

| Area | Before | After |
|---|---|---|
| `CacheTags` (save / purgeQueued / flush ordering) | 41% | **97%** |
| `Tags\WooCommerceTags` / `SiteTags` / `GravityformTags` | 0% | **100%** |
| `KinstaCacheInvalidator` (clear/bulk-flush/flush) | 15% | **58%** |
| `NonceCron` (purge) | 31% | **62%** |

### What's tested
- **Tag vocabulary** — the per-shape branches of each Tag builder (id / array / object / null), since the strings they produce are exactly what gets purged.
- **CacheTags orchestration** — via fake `Store`/`Invalidator`/`Action`: `purgeQueued()` runs invalidators and only clears the store on success (and skips it on failure); `flush()` same ordering; `save()` stores front-end URLs but skips admin; `bindAction`/`hasAction`.
- **Kinsta** — `clear()` posts the purge list to the immediate endpoint, **bulk-flushes** when it would take more than three requests, and `flush()` hits the clear-all endpoint (the real `post()`/cURL path stays out — captured via a subclass).
- **NonceCron::purge()** queues the `nonce` tag.

### Notes
- `KinstaCacheInvalidator::post()` (raw cURL to a Kinsta MU endpoint) isn't exercised — no endpoint in CI; the surrounding orchestration is covered via a `post()` override.
- `PolylangTags` is exercised by passing tests (`TestPolylang`) but reads 0% in the pcov report — an attribution anomaly for that one file (persists with opcache disabled); the assertions genuinely call it.

Remaining lower-coverage spots are the CLI `DatabaseCommand`, the `Polylang`/`Gravityform`/`WooCommerce` *actions*, and `Bootstrap` — mostly framework-wiring and harder-to-reach branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)