### PR TITLE
Add a multisite CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,39 @@ jobs:
 
       - name: Run tests with coverage
         run: npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags ./vendor/bin/phpunit --coverage-text
+
+  multisite:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, mysql, xml, zip
+          coverage: none
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install
+        run: composer update --prefer-dist --no-progress --no-interaction
+
+      - name: Start wp-env
+        run: npx @wordpress/env@latest start
+
+      # wp-env installs single-site; convert the test install so the network
+      # tables and constants exist for the multisite-only tests (@group multisite).
+      - name: Convert the test install to multisite
+        run: npx @wordpress/env@latest run tests-cli wp core multisite-convert
+
+      # No stdout summary here (the HttpHeader action's output buffering swallows
+      # it under multisite) — phpunit's exit code gates the job.
+      - name: Run multisite tests
+        run: npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags bash -c "WP_MULTISITE=1 ./vendor/bin/phpunit --group multisite"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [single-site, multisite]
+
+    name: test (${{ matrix.mode }})
+
     steps:
       - uses: actions/checkout@v4
 
@@ -30,41 +37,8 @@ jobs:
         run: composer update --prefer-dist --no-progress --no-interaction
 
       - name: Lint
+        if: ${{ matrix.mode == 'single-site' }}
         run: composer lint
-
-      - name: Start wp-env
-        run: npx @wordpress/env@latest start
-
-      # The tests run inside the wp-env container, so the coverage driver has to
-      # live there (setup-php's driver is on the runner, not the container).
-      - name: Enable coverage driver (pcov)
-        run: docker exec -u root "$(docker ps -qf name=tests-cli)" sh -c "pecl install pcov && docker-php-ext-enable pcov"
-
-      - name: Run tests with coverage
-        run: npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags ./vendor/bin/phpunit --coverage-text
-
-  multisite:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          extensions: mbstring, mysql, xml, zip
-          coverage: none
-
-      - name: Cache Composer
-        uses: actions/cache@v4
-        with:
-          path: ~/.composer/cache
-          key: composer-${{ hashFiles('composer.lock') }}
-          restore-keys: composer-
-
-      - name: Install
-        run: composer update --prefer-dist --no-progress --no-interaction
 
       - name: Start wp-env
         run: npx @wordpress/env@latest start
@@ -72,9 +46,23 @@ jobs:
       # wp-env installs single-site; convert the test install so the network
       # tables and constants exist for the multisite-only tests (@group multisite).
       - name: Convert the test install to multisite
+        if: ${{ matrix.mode == 'multisite' }}
         run: npx @wordpress/env@latest run tests-cli wp core multisite-convert
 
-      # No stdout summary here (the HttpHeader action's output buffering swallows
-      # it under multisite) — phpunit's exit code gates the job.
-      - name: Run multisite tests
-        run: npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags bash -c "WP_MULTISITE=1 ./vendor/bin/phpunit --group multisite"
+      # The tests run inside the wp-env container, so the coverage driver has to
+      # live there (setup-php's driver is on the runner, not the container).
+      - name: Enable coverage driver (pcov)
+        if: ${{ matrix.mode == 'single-site' }}
+        run: docker exec -u root "$(docker ps -qf name=tests-cli)" sh -c "pecl install pcov && docker-php-ext-enable pcov"
+
+      # Single-site runs the full suite with coverage; multisite runs only the
+      # @group multisite tests under a real network (WP_MULTISITE=1). Under
+      # multisite the HttpHeader action's output buffering swallows phpunit's
+      # stdout summary, so the job is gated by phpunit's exit code.
+      - name: Run tests
+        run: |
+          if [ "${{ matrix.mode }}" = "multisite" ]; then
+            npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags bash -c "WP_MULTISITE=1 ./vendor/bin/phpunit --group multisite"
+          else
+            npx @wordpress/env@latest run tests-cli --env-cwd=wp-content/plugins/sage-cachetags ./vendor/bin/phpunit --coverage-text
+          fi

--- a/tests/integration/test-database.php
+++ b/tests/integration/test-database.php
@@ -39,10 +39,13 @@ class TestDatabase extends WP_UnitTestCase
         $this->assertSame(2, (int) get_option('cachetags_db_version'));
     }
 
+    /**
+     * @group multisite
+     */
     public function test_creates_the_table_for_a_new_multisite_subsite(): void
     {
         if (! is_multisite()) {
-            $this->markTestSkipped('Requires multisite (run with the multisite config).');
+            $this->markTestSkipped('Requires multisite (run via the multisite CI job).');
         }
 
         global $wpdb;


### PR DESCRIPTION
Adds a second CI job that runs the suite's `@group multisite` tests against a **real multisite install**, so the multisite-only code path actually executes (it's `markTestSkipped` in the single-site job).

### How
- `wp-env start` installs single-site, so the job runs `wp core multisite-convert` to create the network tables + constants.
- Then `WP_MULTISITE=1 phpunit --group multisite` — `WP_MULTISITE` tells the WP test framework to set up multisite factories/cleanup; the convert gives it the schema.
- Verified on a fresh env (the CI scenario) via JUnit: `test_creates_the_table_for_a_new_multisite_subsite` passes (1 test, 0 failures), exercising `Bootstrap::createTableForNewSite` (the `wp_initialize_site` hook).

The job is **exit-code-gated** — under multisite the `HttpHeader` action's output buffering swallows phpunit's stdout summary, so the CI log won't show the dots/summary, but a failing test still fails the job.

### Scope
Only the subsite-table-provisioning test is in `@group multisite` — it's the meaningful multisite production path and runs reliably. Two other multisite branches (`SiteTags::sites('any')`, the `DatabaseCommand` per-site loop) hit wp-env multisite-environment limits when creating extra blocks in-test (`UPLOADBLOGSDIR` undefined; wp-env's convert doesn't fully replicate a multisite boot), so they're left out rather than patched with WP-internals hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)