### PR TITLE
Test coverage batch 8: CoreTags branches, Gravityform, RestApi user/parent (→89%)

### DIFF
--- a/tests/integration/test-gravityform.php
+++ b/tests/integration/test-gravityform.php
@@ -30,6 +30,61 @@ class TestGravityform extends WP_UnitTestCase
         return $action;
     }
 
+    private function resetTags(): CacheTags
+    {
+        $cacheTags = CacheTags::getInstance();
+        $ref = new ReflectionProperty($cacheTags, 'cacheTags');
+        $ref->setAccessible(true);
+        $ref->setValue($cacheTags, []);
+
+        return $cacheTags;
+    }
+
+    public function test_bind_registers_the_gravity_forms_hooks(): void
+    {
+        $action = new Gravityform(CacheTags::getInstance());
+        $action->bind();
+
+        $this->assertNotFalse(has_filter('gform_pre_render', [$action, 'addGravityformCacheTags']));
+        $this->assertNotFalse(has_action('gform_after_save_form', [$action, 'onSaveForm']));
+        $this->assertNotFalse(has_filter('cachetags/cacheable', [$action, 'isCacheable']));
+    }
+
+    public function test_a_non_array_form_is_passed_through_untouched(): void
+    {
+        // gform_pre_render can receive false (e.g. form not found).
+        $this->assertFalse((new Gravityform(CacheTags::getInstance()))->addGravityformCacheTags(false));
+    }
+
+    public function test_rendering_tags_the_form_and_a_fileupload_adds_the_nonce_tag(): void
+    {
+        $cacheTags = $this->resetTags();
+
+        $this->render([
+            ['type' => 'fileupload', 'allowsPrepopulate' => false],
+        ]);
+
+        $tags = $cacheTags->get();
+        $this->assertContains('gform:1', $tags);
+        $this->assertContains('nonce', $tags, 'file uploads use a per-session nonce');
+    }
+
+    public function test_on_save_clears_an_existing_form_but_not_a_brand_new_one(): void
+    {
+        $cacheTags = CacheTags::getInstance();
+        $purge = new ReflectionProperty($cacheTags, 'purgeTags');
+        $purge->setAccessible(true);
+        $action = new Gravityform($cacheTags);
+
+        $purge->setValue($cacheTags, []);
+        $action->onSaveForm(['id' => 7], false);
+        $this->assertContains('gform:7', $purge->getValue($cacheTags));
+
+        $purge->setValue($cacheTags, []);
+        $action->onSaveForm(['id' => 7], true);
+        $this->assertNotContains('gform:7', $purge->getValue($cacheTags), 'a new form has nothing cached yet');
+    }
+
     public function test_prepopulated_form_request_is_non_cacheable(): void
     {
         $action = $this->render([

--- a/tests/integration/test-rest-content-tagging.php
+++ b/tests/integration/test-rest-content-tagging.php
@@ -285,4 +285,28 @@ class TestRestContentTagging extends RestTestCase
 
         return $request;
     }
+
+    public function test_user_endpoint_is_tagged_with_the_user(): void
+    {
+        // The author is exposed at /users because they have a published post.
+        $response = $this->dispatch(new WP_REST_Request('GET', "/wp/v2/users/{$this->authorId}"));
+
+        $this->assertContains("user:{$this->authorId}", $this->cacheTagHeader($response));
+    }
+
+    public function test_hierarchical_post_is_tagged_with_its_parent(): void
+    {
+        $parentId = self::factory()->post->create(['post_type' => 'page', 'post_status' => 'publish']);
+        $childId = self::factory()->post->create([
+            'post_type' => 'page',
+            'post_status' => 'publish',
+            'post_parent' => $parentId,
+        ]);
+
+        $response = $this->dispatch(new WP_REST_Request('GET', "/wp/v2/pages/{$childId}"));
+        $tags = $this->cacheTagHeader($response);
+
+        $this->assertContains("post:{$childId}", $tags);
+        $this->assertContains("post:{$parentId}", $tags, 'breadcrumbs/ancestry depend on the parent');
+    }
 }

--- a/tests/unit/test-core-tags.php
+++ b/tests/unit/test-core-tags.php
@@ -135,4 +135,66 @@ class TestCoreTags extends WP_UnitTestCase
 
         $this->assertContains('my_option', CoreTags::getCacheableOptions());
     }
+
+    public function test_any_keyword_expands_to_the_cacheable_sets(): void
+    {
+        $this->assertContains('archive:post', CoreTags::archive('any'));
+        $this->assertContains('taxonomy:category', CoreTags::taxonomy('any'));
+        $this->assertContains('taxonomy:category:any', CoreTags::anyTerm('any'));
+        $this->assertContains('archive:post:any', CoreTags::anyArchive('any'));
+        $this->assertContains('role:administrator', CoreTags::anyUser('any'));
+    }
+
+    public function test_set_builders_accept_wp_objects(): void
+    {
+        $this->assertSame(['archive:post'], CoreTags::archive(get_post_type_object('post')));
+        $this->assertSame(['archive:post:any'], CoreTags::anyArchive(get_post_type_object('post')));
+        $this->assertSame(['taxonomy:category'], CoreTags::taxonomy(get_taxonomy('category')));
+        $this->assertSame(['taxonomy:category:any'], CoreTags::anyTerm(get_taxonomy('category')));
+        $this->assertSame(['role:administrator'], CoreTags::anyUser(get_role('administrator')));
+    }
+
+    public function test_builders_return_empty_for_unusable_input(): void
+    {
+        $this->assertSame([], CoreTags::terms(null));
+        $this->assertSame([], CoreTags::users(null));
+        $this->assertSame([], CoreTags::comments(null));
+        $this->assertSame([], CoreTags::archive(123));
+        $this->assertSame([], CoreTags::taxonomy(123));
+        $this->assertSame([], CoreTags::anyTerm(123));
+        $this->assertSame([], CoreTags::anyArchive(123));
+        $this->assertSame([], CoreTags::anyUser(123));
+        $this->assertSame([], CoreTags::menu(null));
+    }
+
+    public function test_menu_resolves_a_slug_and_throws_for_an_unknown_one(): void
+    {
+        wp_create_nav_menu('Primary');
+        $expectedId = get_term_by('slug', 'primary', 'nav_menu')->term_id;
+
+        $this->assertSame(["menu:{$expectedId}"], CoreTags::menu('primary'));
+
+        $this->expectException(Exception::class);
+        CoreTags::menu('no-such-menu');
+    }
+
+    public function test_queried_object_throws_for_an_unsupported_object(): void
+    {
+        $this->expectException(Exception::class);
+        CoreTags::queriedObject(self::factory()->user->create_and_get());
+    }
+
+    public function test_is_cacheable_predicates_accept_objects_ids_and_terms(): void
+    {
+        $postId = self::factory()->post->create();
+        $termId = self::factory()->category->create();
+
+        $this->assertTrue(CoreTags::isCacheablePostType(get_post_type_object('post')));
+        $this->assertTrue(CoreTags::isCacheablePostType($postId));
+        $this->assertTrue(CoreTags::isCacheablePostType(get_post($postId)));
+
+        $this->assertTrue(CoreTags::isCacheableTaxonomy(get_taxonomy('category')));
+        $this->assertTrue(CoreTags::isCacheableTaxonomy($termId));
+        $this->assertTrue(CoreTags::isCacheableTaxonomy(get_term($termId)));
+    }
 }


### PR DESCRIPTION
A pass over the remaining bug-prone branches (real tests, no new mocks). **Lines 85.6% → 88.9%**, methods 61% → 69%, 248 tests.

### What's now tested
- **`CoreTags`** (the tag vocabulary → 100%): the `'any'` keyword expansion for `archive`/`taxonomy`/`anyTerm`/`anyArchive`/`anyUser`, the `WP_Post_Type`/`WP_Taxonomy`/`WP_Role` object inputs, the empty-input fallbacks, `menu(slug)` resolution + its `throw` for an unknown slug, `queriedObject`'s `throw` for an unsupported object, and the object/id/term forms of `isCacheablePostType`/`isCacheableTaxonomy`. Added to the existing unit test.
- **`Gravityform` action**: `bind()`, the non-array `gform_pre_render` passthrough, the **fileupload → `nonce` tag** path, and `onSaveForm` (clears an existing form's tag, no-ops a brand-new form). All pure array processing — no Gravity Forms runtime needed.
- **`RestApi`**: the **user endpoint** (`tagUser`, exposed because the author has a published post) and the **hierarchical-parent** related tag (a child page's response tags its parent for breadcrumb/ancestry purging).

### Left out (deliberately)
- `WpRocketCacheInvalidator`'s `! function_exists` guards — once the test suite stubs `rocket_clean_*`, those false-branches are unreachable; not worth a process-isolation hack for two defensive lines.
- A few `bind()`/CLI lines that run during the phpunit bootstrap phase (pre-pcov) and the multisite-only `DatabaseCommand` loop (covered behaviourally by the multisite job's `createTableForNewSite`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)