### PR TITLE
v3 — structured `Tag` everywhere (#53), parallel Fastly purges (#54) + defaults/provider/perf pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,23 +527,34 @@ To manage the action list entirely yourself, turn detection off:
 (new Bootstrap)->autoDetectActions(false)->/* … */->bootstrap();
 ```
 
+### Flushing all pages, or a whole language
+
+Every cacheable page and REST response carries a base `page` tag, so a single
+purge clears all WordPress-served pages at once — static assets (images/CSS/JS),
+which never carry it, stay cached:
+
+```sh
+wp cachetags clear page
+```
+
+Rename it or turn it off with `'base-tag' => null` (config) / `->baseTag(null)`
+(bootstrap).
+
+When Polylang is active, every page is also tagged with its language, so you can
+clear all content in one language:
+
+```sh
+wp cachetags clear lang:fi
+```
+
 ### The `Site` action
 
-Enable the `Site` action to tag every WordPress-served page with a `site:{id}` key
-and prefix all other tags with it (`site:1:post:123`). Two uses, both common:
-
-- **Flush all dynamic pages in one purge — even on a single site.** Every
-  WP-rendered page carries `site:1`, but static assets (images/CSS/JS) don't, so
-  purging that one tag clears the whole site's pages at the edge while leaving
-  assets cached:
-
-  ```sh
-  wp cachetags clear site:1
-  ```
-
-- **Multisite scoping.** When one edge (e.g. a single Fastly service) fronts the
-  whole network, the `site:{id}:` prefix keeps a purge on one site from clearing
-  same-id content (`post:123`) on another.
+On multisite where one edge (e.g. a single Fastly service) fronts the whole
+network, enable the `Site` action. It prefixes every tag with the site id
+(`site:5:post:123`) so a purge on one site never clears same-id content on
+another, and tags each page with `site:{id}` for a per-site flush-all
+(`wp cachetags clear site:5`). On a single site you don't need it — the base
+`page` tag above already gives flush-all without the per-tag prefixing.
 
 ### Multisite tables
 

--- a/README.md
+++ b/README.md
@@ -515,9 +515,9 @@ automatically — you don't need to list it in `action`:
   in one language only purges that language's listings, and clears the right
   language archives on publish/unpublish/delete.
 - **Gravity Forms** keeps prepopulated forms out of the shared cache and purges a
-  form's pages when it changes. Its file-upload forms use a per-session nonce, so
-  the [nonce cron](#nonces-in-cached-pages) also turns itself on when Gravity Forms
-  is active (`'nonce-cron' => null` = auto; set `true`/`false` to force it).
+  form's pages when it changes. It tags file-upload form pages `nonce`; the
+  always-on [`Nonce` action](#nonces-in-cached-pages) (not Gravity Forms) purges
+  those before the nonce expires.
 
 To manage the action list entirely yourself, turn detection off:
 
@@ -559,6 +559,9 @@ network, enable the `Site` action. It prefixes every tag with the site id
 another, and tags each page with `site:{id}` for a per-site flush-all
 (`wp cachetags clear site:5`). On a single site you don't need it — the base
 `page` tag above already gives flush-all without the per-tag prefixing.
+
+Note the `Site` prefix also applies to the base tag, so with `Site` active the
+flush-all key is per-site `site:5:page` rather than the bare `page`.
 
 ### Multisite tables
 

--- a/README.md
+++ b/README.md
@@ -399,21 +399,23 @@ for 12–24h; once one ages out, the action it guards (a form submit, an AJAX
 
 Two ways to handle a page that bakes a nonce into its HTML:
 
-1. **Tag it `nonce` and enable the nonce cron.** The page is then purged every
-   12 hours, before any embedded nonce can expire. Enable `'nonce-cron' => true`
-   in the config (or `->nonceCron()` on `Bootstrap`), and add the tag wherever
-   the nonce is rendered:
+1. **Tag it `nonce`.** The page is then purged every 12 hours by the nonce cron,
+   before any embedded nonce can expire. When **Gravity Forms** is active its
+   action handles this automatically (it tags file-upload form pages and schedules
+   the cron). To tag your own page, add the tag where the nonce renders — and, if
+   you're *not* relying on Gravity Forms, schedule the cron once with
+   `NonceCron::register()`:
 
    ```php
    // e.g. a product page that prints a WooCommerce Store API nonce for add-to-cart
+   \Genero\Sage\CacheTags\NonceCron::register(); // no-op if already scheduled
+
    add_action('wp_footer', function () {
        if (function_exists('is_product') && is_product()) {
            \Genero\Sage\CacheTags\CacheTags::getInstance()?->add(['nonce']);
        }
    });
    ```
-
-   The `Gravityform` action already does this for file-upload fields.
 
 2. **Mark it non-cacheable** when the page also shows genuinely real-time data
    (e.g. live availability), where a 12h refresh isn't enough:
@@ -504,16 +506,20 @@ class ArticleList extends Block
 
 ## Integrations
 
-### WooCommerce & Polylang (auto-enabled)
+### WooCommerce, Polylang & Gravity Forms (auto-enabled)
 
-When WooCommerce or Polylang is active, its action is enabled automatically — you
-don't need to list it in `action`:
+When WooCommerce, Polylang or Gravity Forms is active, its action is enabled
+automatically — you don't need to list it in `action`:
 
 - **WooCommerce** keeps cart/checkout/account out of the shared cache and purges a
   product (plus its archives) on price/stock/status changes.
 - **Polylang** makes archive tags language-specific (`archive:post:fi`) so a change
   in one language only purges that language's listings, and clears the right
   language archives on publish/unpublish/delete.
+- **Gravity Forms** keeps prepopulated forms out of the shared cache and purges a
+  form's pages when it changes. Its file-upload forms use a per-session nonce, so
+  the [nonce cron](#nonces-in-cached-pages) also turns itself on when Gravity Forms
+  is active (`'nonce-cron' => null` = auto; set `true`/`false` to force it).
 
 To manage the action list entirely yourself, turn detection off:
 

--- a/README.md
+++ b/README.md
@@ -399,23 +399,21 @@ for 12–24h; once one ages out, the action it guards (a form submit, an AJAX
 
 Two ways to handle a page that bakes a nonce into its HTML:
 
-1. **Tag it `nonce`.** The page is then purged every 12 hours by the nonce cron,
-   before any embedded nonce can expire. When **Gravity Forms** is active its
-   action handles this automatically (it tags file-upload form pages and schedules
-   the cron). To tag your own page, add the tag where the nonce renders — and, if
-   you're *not* relying on Gravity Forms, schedule the cron once with
-   `NonceCron::register()`:
+1. **Tag it `nonce`.** The page is then purged every 12 hours, before any embedded
+   nonce can expire. The `Nonce` action runs that cron and is enabled by default,
+   so you only need to add the tag where the nonce renders (the `Gravityform`
+   action already does this for file-upload forms):
 
    ```php
    // e.g. a product page that prints a WooCommerce Store API nonce for add-to-cart
-   \Genero\Sage\CacheTags\NonceCron::register(); // no-op if already scheduled
-
    add_action('wp_footer', function () {
        if (function_exists('is_product') && is_product()) {
            \Genero\Sage\CacheTags\CacheTags::getInstance()?->add(['nonce']);
        }
    });
    ```
+
+   Remove `Nonce::class` from the `action` config to opt out of the cron.
 
 2. **Mark it non-cacheable** when the page also shows genuinely real-time data
    (e.g. live availability), where a 12h refresh isn't enough:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Two invalidators, differing in how Kinsta resolves the purge:
   request. It disables query-string storage (`cachetags/store-query-string`)
   since the bare path is enough, keeping the store lean. This is the right choice
   for a standard Kinsta setup, where query-string URLs bypass the cache anyway.
+  Collapsing many URLs into a single prefix purge also keeps **purge volume low**
+  — Kinsta dispatches purges to its edge (Cloudflare) asynchronously and rate-
+  limits/coalesces them server-side, and the localhost endpoint returns `200` on
+  *accept* (downstream throttling is invisible to the request), so fewer, coarser
+  purges are the most effective way to stay under those limits. Bulk purges are
+  additionally routed to Kinsta's throttled endpoint rather than a full flush.
 - **`KinstaCacheInvalidator`** purges by `single|` — the exact URL only. Use this
   if you've configured Kinsta to cache query-string URLs and need each variant
   purged by its full stored URL (see [Stored URL and query strings](#stored-url-and-query-strings)).

--- a/README.md
+++ b/README.md
@@ -674,13 +674,16 @@ Tag::archive('post')->qualify($lang);                 // archive:post:fi
 
 The builder classes (`CoreTags`, `WooCommerceTags`, `SiteTags`, `PolylangTags`,
 `GravityformTags`) return `Tag[]`; pass them — and any plain strings — straight to
-`add()`/`clear()`:
+`add()`/`clear()`. Both take tags as individual arguments or arrays, nested
+freely:
 
 ```php
+$cacheTags->add(Tag::nonce());                 // a single tag
+$cacheTags->add('post:5', Tag::term(9));       // several arguments
 $cacheTags->add([
     Tag::archive('product'),
-    ...CoreTags::posts($ids),   // CoreTags returns Tag[]
-    'my:custom:tag',            // plain strings still work
+    ...CoreTags::posts($ids),                  // CoreTags returns Tag[]
+    'my:custom:tag',                           // plain strings still work
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -626,15 +626,57 @@ use Genero\Sage\CacheTags\CacheTags;
 $cacheTags = CacheTags::getInstance();
 ```
 
+### Building tags with `Tag`
+
+Tags are `Tag` value objects — fluent to build, serialized to their string form
+(`post:5`, `archive:post:any`, `site:5:term:9`) only at the edge (header, store,
+purge). `add()` and `clear()` accept Tags, plain strings, and nested arrays
+interchangeably, so you rarely touch `Tag` directly — but it's there when you want
+type-safety or context.
+
+```php
+use Genero\Sage\CacheTags\Tag;
+
+Tag::post(5);                    // post:5
+Tag::archive('product');         // archive:product
+Tag::archive('product')->any();  // archive:product:any  (any product changing)
+Tag::term(9)->full();            // term:9:full
+Tag::option('blogname');         // option:blogname
+Tag::of('my-type', $id);         // an arbitrary custom type
+```
+
+Context is two general, composable operations — `scope()` to namespace a tag and
+`qualify()` for a variant — so new dimensions (a multisite network, a tenant) need
+no new API:
+
+```php
+Tag::post(5)->scope('site', 5);                       // site:5:post:5
+Tag::post(5)->scope('network', 2)->scope('site', 5);  // network:2:site:5:post:5
+Tag::archive('post')->qualify($lang);                 // archive:post:fi
+```
+
+The builder classes (`CoreTags`, `WooCommerceTags`, `SiteTags`, `PolylangTags`,
+`GravityformTags`) return `Tag[]`; pass them — and any plain strings — straight to
+`add()`/`clear()`:
+
+```php
+$cacheTags->add([
+    Tag::archive('product'),
+    ...CoreTags::posts($ids),   // CoreTags returns Tag[]
+    'my:custom:tag',            // plain strings still work
+]);
+```
+
 ### Create a custom tag
 
-The nicest way is to look at the code of this repo and create a custom `Action` and maybe a `CustomTag` class that you use, but the logic is really nothing more than:
+The nicest way is to look at the code of this repo and create a custom `Action`, but the logic is really nothing more than:
 
 **With Acorn:**
 ```php
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tag;
 
-// Tag content
+// Tag content (a bare string, or Tag::of('custom-tag') / Tag::of('thing', $id))
 app(CacheTags::class)->add(['custom-tag']);
 
 // Clear it whenever you want

--- a/README.md
+++ b/README.md
@@ -306,15 +306,14 @@ safe (for both front-end pages and REST responses):
   taxonomy. This over-purges rather than dropping tags.
 
 ```php
-// Tag header byte budget before collapsing to coarse tags (default 16384).
+// Tag header byte budget before collapsing to coarse tags (default 16384,
+// Fastly's Surrogate-Key total). Tune it for a provider with a different limit.
 add_filter('cachetags/max-header-bytes', fn () => 8192);
-
-// Maximum length of a single tag (default 191, the store column width).
-add_filter('cachetags/max-tag-length', fn () => 191);
-
-// Pattern a tag must match to be kept.
-add_filter('cachetags/tag-pattern', fn () => '/^[^\s\x00-\x1F]+$/');
 ```
+
+(The single-tag length cap — 191, the `varchar(191)` store column — and the
+header-token validation pattern are fixed, not filterable: they're tied to the
+schema and to header safety.)
 
 ## Front-end tagging
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,8 +40,28 @@ or passing them to something typed `string[]`. Wrap with `Tag::toStrings()`:
 +$strings = Tag::toStrings(CoreTags::posts($ids));
 ```
 
-Your own custom string tags, the `cachetags/filter-tags` filter, and the
-`Store`/`Invalidator` payloads are all still plain strings — unchanged.
+Your own custom string tags and the `Store`/`Invalidator` payloads are all still
+plain strings — unchanged.
+
+### `cachetags/filter-tags` now passes `Tag[]`
+
+The `cachetags/filter-tags` filter receives and returns an array of `Tag` objects
+instead of strings, so tags stay structured through the whole pipeline. A filter
+that built strings can use the `Tag` API instead, and returning plain strings
+still works (they're parsed back):
+
+```diff
+ add_filter('cachetags/filter-tags', function (array $tags) {
+-    $tags[] = "site:{$id}:" . $tag;          // string munging
++    $tags[] = Tag::of($type, $id)->scope('site', $id);
+     return $tags;
+ });
+```
+
+Output is still validated before it reaches the header, so a filter can't smuggle
+a header-unsafe tag through. The bundled `Site` and `Polylang` actions already use
+this. (No release shipped a consumer of this filter; this only matters if you hook
+it yourself.)
 
 ### Internal state is now `Tag[]`
 
@@ -93,8 +113,9 @@ this replaces the trick of enabling the `Site` action just to get a flush-all ke
 ### Unchanged
 
 Compatible without changes: `CacheTags::add/clear/save/flush/getInstance/hasAction`
-and the public `invalidators` property; every `cachetags/*` filter (incl.
-`cachetags/filter-tags`, still `string[] → string[]`); the `Store`, `Invalidator`
+and the public `invalidators` property; the config filters (`cachetags/cacheable`,
+`cachetags/url-ignored-params`, `cachetags/options`, …); the `Store`, `Invalidator`
 and `Action` contracts; the bundled actions/invalidators/stores; the `Bootstrap`
 fluent API and `CacheTagsServiceProvider`; `Util::normalizeTags()`; the config
-keys; and the WP-CLI commands.
+keys; and the WP-CLI commands. (`cachetags/filter-tags` is the one filter whose
+signature changed — see above.)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,14 @@ Tag::archive('post')->qualify($lang)                 // language variant
 Tag::of('my-type', $id)                              // arbitrary type
 ```
 
+### New default: a `page` base tag on every page
+
+Every cacheable page and REST response is now tagged with `page`, so
+`wp cachetags clear page` flushes all WordPress-served pages (assets stay cached).
+It's additive — one extra tag per page. Rename or disable it with
+`'base-tag' => null` (config) or `->baseTag(null)` (bootstrap). On single sites
+this replaces the trick of enabling the `Site` action just to get a flush-all key.
+
 ### Unchanged
 
 Compatible without changes: `CacheTags::add/clear/save/flush/getInstance/hasAction`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -77,6 +77,19 @@ It's additive — one extra tag per page. Rename or disable it with
 `'base-tag' => null` (config) or `->baseTag(null)` (bootstrap). On single sites
 this replaces the trick of enabling the `Site` action just to get a flush-all key.
 
+### New defaults: auto-enabled integrations & nonce cron
+
+- **Gravity Forms** now auto-enables (joining WooCommerce and Polylang) when its
+  plugin is active — it no longer needs to be listed in `action`. If you publish
+  the config, `Gravityform::class` is dropped from the default `action` list (it's
+  detected instead). Turn detection off with `'auto-detect-actions' => false`.
+- **Nonce cron** is now owned by the Gravity Forms action — it schedules the
+  12-hour purge of `nonce`-tagged pages (file-upload forms) when bound, and the
+  schedule is cleaned up when the action isn't active. The `'nonce-cron'` config
+  key and `Bootstrap::nonceCron()` are **removed** (the cron only ever mattered
+  with Gravity Forms, the sole producer of `nonce` tags). For a custom nonce
+  tagger without Gravity Forms, call `NonceCron::register()` yourself.
+
 ### Unchanged
 
 Compatible without changes: `CacheTags::add/clear/save/flush/getInstance/hasAction`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,79 @@
+# Upgrading
+
+## 3.0
+
+3.0 reworks cache tags from plain strings into a structured `Tag` value object
+internally. **Most projects need no code changes** — bump the composer constraint
+and you're done. The one breaking change affects only code that treats the tag
+*builder* output as strings.
+
+Audited against solarplexius, herrfors, beamex and kaskipuu: all four needed only
+the composer bump (plus, for herrfors, a one-line test tweak — see below).
+
+### Required: composer constraint
+
+```diff
+-    "generoi/sage-cachetags": "^2.5"
++    "generoi/sage-cachetags": "^3.0"
+```
+
+### Breaking: tag builders return `Tag[]`, not `string[]`
+
+`CoreTags`, `SiteTags`, `PolylangTags`, `WooCommerceTags` and `GravityformTags`
+builder methods (`posts()`, `archive()`, `terms()`, `anyTerm()`, `navigation()`,
+…) now return an array of `Tag` objects instead of strings.
+
+**No change needed** when you pass their output to `CacheTags::add()` / `clear()`
+— the common case, including the `BlockCacheTags` / `ComposerCacheTags` traits.
+Tags stringify, and `add()`/`clear()` accept strings *and* Tags, mixed:
+
+```php
+$cacheTags->add([...CoreTags::archive('product'), 'my:custom:tag']); // fine
+```
+
+**Change needed** only if you consume a builder's return value *as strings* —
+`implode()`, a strict `in_array('post:5', $tags, true)`, `===`, persisting them,
+or passing them to something typed `string[]`. Wrap with `Tag::toStrings()`:
+
+```diff
+-$strings = CoreTags::posts($ids);
++$strings = Tag::toStrings(CoreTags::posts($ids));
+```
+
+Your own custom string tags, the `cachetags/filter-tags` filter, and the
+`Store`/`Invalidator` payloads are all still plain strings — unchanged.
+
+### Internal state is now `Tag[]`
+
+If you reflect into `CacheTags`' protected `cacheTags` / `purgeTags` properties
+(e.g. in a test), they now hold `Tag` objects. Cast before string assertions:
+
+```diff
+-$queued = $reflectedPurgeTags;
++$queued = Tag::toStrings($reflectedPurgeTags);
+```
+
+### New (optional): the fluent `Tag` API
+
+Build tags expressively — context is two general, composable operations
+(`scope()` for namespacing, `qualify()` for a variant), so new dimensions need no
+new API:
+
+```php
+Tag::post(5)
+Tag::archive('post')->any()
+Tag::term(9)->full()
+Tag::post(5)->scope('site', 5)                       // multisite
+Tag::post(5)->scope('network', 2)->scope('site', 5)  // composes
+Tag::archive('post')->qualify($lang)                 // language variant
+Tag::of('my-type', $id)                              // arbitrary type
+```
+
+### Unchanged
+
+Compatible without changes: `CacheTags::add/clear/save/flush/getInstance/hasAction`
+and the public `invalidators` property; every `cachetags/*` filter (incl.
+`cachetags/filter-tags`, still `string[] → string[]`); the `Store`, `Invalidator`
+and `Action` contracts; the bundled actions/invalidators/stores; the `Bootstrap`
+fluent API and `CacheTagsServiceProvider`; `Util::normalizeTags()`; the config
+keys; and the WP-CLI commands.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,12 +83,12 @@ this replaces the trick of enabling the `Site` action just to get a flush-all ke
   plugin is active — it no longer needs to be listed in `action`. If you publish
   the config, `Gravityform::class` is dropped from the default `action` list (it's
   detected instead). Turn detection off with `'auto-detect-actions' => false`.
-- **Nonce cron** is now owned by the Gravity Forms action — it schedules the
-  12-hour purge of `nonce`-tagged pages (file-upload forms) when bound, and the
-  schedule is cleaned up when the action isn't active. The `'nonce-cron'` config
-  key and `Bootstrap::nonceCron()` are **removed** (the cron only ever mattered
-  with Gravity Forms, the sole producer of `nonce` tags). For a custom nonce
-  tagger without Gravity Forms, call `NonceCron::register()` yourself.
+- **Nonce cron** is now a default `Nonce` action (in the published config's
+  `action` list) that schedules the 12-hour purge of `nonce`-tagged pages. The
+  `'nonce-cron'` config key and `Bootstrap::nonceCron()` are **removed** — it's on
+  by default (a light twice-daily cron), so any page tagged `nonce`, including a
+  theme's own, is covered without wiring a cron. Opt out by removing `Nonce::class`
+  from `action`.
 
 ### Unchanged
 

--- a/config/cachetags.php
+++ b/config/cachetags.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Actions\Core;
 use Genero\Sage\CacheTags\Actions\DebugComment;
+use Genero\Sage\CacheTags\Actions\Nonce;
 use Genero\Sage\CacheTags\Invalidators\SuperCacheInvalidator;
 use Genero\Sage\CacheTags\Stores\WordpressDbStore;
 
@@ -28,6 +29,10 @@ return [
     'action' => [
         Core::class,
         DebugComment::class,
+
+        // Purge pages tagged 'nonce' twice daily so a cached page never serves an
+        // expired nonce. Light cron; remove this to opt out.
+        Nonce::class,
 
         // WooCommerce / Polylang / Gravity Forms are added automatically when
         // active (see auto-detect-actions above); list them here to force them on.

--- a/config/cachetags.php
+++ b/config/cachetags.php
@@ -20,6 +20,11 @@ return [
     // entirely via 'action' below.
     'auto-detect-actions' => true,
 
+    // A tag added to every cacheable page and REST response, so one purge
+    // (`wp cachetags clear page`) clears all WordPress-served pages while static
+    // assets stay cached. Set to null to disable, or rename it.
+    'base-tag' => 'page',
+
     'action' => [
         Core::class,
         DebugComment::class,

--- a/config/cachetags.php
+++ b/config/cachetags.php
@@ -2,7 +2,6 @@
 
 use Genero\Sage\CacheTags\Actions\Core;
 use Genero\Sage\CacheTags\Actions\DebugComment;
-use Genero\Sage\CacheTags\Actions\Gravityform;
 use Genero\Sage\CacheTags\Invalidators\SuperCacheInvalidator;
 use Genero\Sage\CacheTags\Stores\WordpressDbStore;
 
@@ -14,13 +13,14 @@ return [
     'invalidator' => [
         SuperCacheInvalidator::class,
     ],
-    // Auto-enable the WooCommerce and Polylang actions when their plugin is
-    // active (WooCommerce keeps cart/checkout/account out of the shared cache;
-    // Polylang adds language-aware purging). Set false to manage the action list
-    // entirely via 'action' below.
+
+    // The WooCommerce, Polylang and Gravity Forms actions are auto-enabled when
+    // their plugin is active — cart/checkout/account stay uncached, language-aware
+    // purging, and prepopulated-form handling. Set false to manage 'action'
+    // entirely yourself.
     'auto-detect-actions' => true,
 
-    // A tag added to every cacheable page and REST response, so one purge
+    // A tag on every cacheable page + REST response, so one purge
     // (`wp cachetags clear page`) clears all WordPress-served pages while static
     // assets stay cached. Set to null to disable, or rename it.
     'base-tag' => 'page',
@@ -28,7 +28,9 @@ return [
     'action' => [
         Core::class,
         DebugComment::class,
-        Gravityform::class,
+
+        // WooCommerce / Polylang / Gravity Forms are added automatically when
+        // active (see auto-detect-actions above); list them here to force them on.
 
         // Tag REST API read responses for headless/decoupled setups. Keep Core
         // enabled alongside it so block-derived tags are collected too.
@@ -44,16 +46,4 @@ return [
         // login cookie. Cart/checkout/account still bypass.
         // \Genero\Sage\CacheTags\Actions\CacheCustomers::class,
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Nonce Cron
-    |--------------------------------------------------------------------------
-    |
-    | When enabled, WP-Cron will purge cache for pages tagged with 'nonce'
-    | every 12 hours. Enable this when using forms with file uploads (e.g.
-    | Gravity Forms) that are cached, since nonces expire after 12-24 hours.
-    |
-    */
-    'nonce-cron' => false,
 ];

--- a/config/cachetags.php
+++ b/config/cachetags.php
@@ -23,7 +23,8 @@ return [
 
     // A tag on every cacheable page + REST response, so one purge
     // (`wp cachetags clear page`) clears all WordPress-served pages while static
-    // assets stay cached. Set to null to disable, or rename it.
+    // assets stay cached. Set to null to disable, or rename it. (Wired by the
+    // BaseTag action automatically from this value — it isn't listed in 'action'.)
     'base-tag' => 'page',
 
     'action' => [
@@ -33,6 +34,10 @@ return [
         // Purge pages tagged 'nonce' twice daily so a cached page never serves an
         // expired nonce. Light cron; remove this to opt out.
         Nonce::class,
+
+        // Emit the cache-tag HTTP header (above) for surrogate-key CDNs like
+        // Fastly. Not needed for URL/store-based purging (e.g. WP Super Cache).
+        // \Genero\Sage\CacheTags\Actions\HttpHeader::class,
 
         // WooCommerce / Polylang / Gravity Forms are added automatically when
         // active (see auto-detect-actions above); list them here to force them on.

--- a/src/Actions/AutoTag.php
+++ b/src/Actions/AutoTag.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\CoreTags;
 use WP_Post;
 use WP_Query;
@@ -105,7 +106,7 @@ class AutoTag implements Action
      * Tag for a single queried post row in whatever shape `fields` produced.
      *
      * @param  mixed  $post
-     * @return string[]
+     * @return Tag[]
      */
     protected function postTag($post): array
     {

--- a/src/Actions/BaseTag.php
+++ b/src/Actions/BaseTag.php
@@ -23,6 +23,6 @@ class BaseTag implements Action
 
     public function addBaseTag(): void
     {
-        $this->cacheTags->add([$this->tag]);
+        $this->cacheTags->add($this->tag);
     }
 }

--- a/src/Actions/BaseTag.php
+++ b/src/Actions/BaseTag.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Actions;
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Contracts\Action;
+
+/**
+ * Tag every cacheable page and REST response with a single base tag, so one
+ * purge clears all WordPress-served pages at once while static assets (which
+ * never carry it) stay cached. Wired by Bootstrap with the configured tag name;
+ * disable by setting the base tag to null.
+ */
+class BaseTag implements Action
+{
+    public function __construct(protected CacheTags $cacheTags, protected string $tag = 'page') {}
+
+    public function bind(): void
+    {
+        \add_action('template_redirect', [$this, 'addBaseTag']);
+        \add_action('rest_api_init', [$this, 'addBaseTag']);
+    }
+
+    public function addBaseTag(): void
+    {
+        $this->cacheTags->add([$this->tag]);
+    }
+}

--- a/src/Actions/Core.php
+++ b/src/Actions/Core.php
@@ -61,9 +61,7 @@ class Core implements Action
                 break;
             case is_single():
             case is_page():
-                $this->cacheTags->add([
-                    ...CoreTags::queriedObject(),
-                ]);
+                $this->cacheTags->add(CoreTags::queriedObject());
                 break;
             case is_category():
             case is_tag():
@@ -74,31 +72,21 @@ class Core implements Action
                 ]);
                 break;
             case is_home():
-                $this->cacheTags->add([
-                    ...CoreTags::archive('post'),
-                ]);
+                $this->cacheTags->add(CoreTags::archive('post'));
                 break;
             case is_post_type_archive():
-                $this->cacheTags->add([
-                    ...CoreTags::archive(get_query_var('post_type')),
-                ]);
+                $this->cacheTags->add(CoreTags::archive(get_query_var('post_type')));
                 break;
             case is_author():
-                $this->cacheTags->add([
-                    ...CoreTags::users(get_query_var('author')),
-                ]);
+                $this->cacheTags->add(CoreTags::users(get_query_var('author')));
                 break;
             case is_attachment():
-                $this->cacheTags->add([
-                    ...CoreTags::queriedObject(),
-                ]);
+                $this->cacheTags->add(CoreTags::queriedObject());
                 break;
             case is_date():
             case is_search():
                 // Listings of any post that publishes/unpublishes into them.
-                $this->cacheTags->add([
-                    ...CoreTags::archive('post'),
-                ]);
+                $this->cacheTags->add(CoreTags::archive('post'));
                 break;
         }
     }
@@ -230,9 +218,7 @@ class Core implements Action
             return;
         }
 
-        $this->cacheTags->clear([
-            ...CoreTags::posts($commentData['comment_post_ID']),
-        ]);
+        $this->cacheTags->clear(CoreTags::posts($commentData['comment_post_ID']));
     }
 
     /**
@@ -419,9 +405,7 @@ class Core implements Action
      */
     public function onAttachmentEdit(int $attachmentId): void
     {
-        $this->cacheTags->clear([
-            ...CoreTags::posts($attachmentId),
-        ]);
+        $this->cacheTags->clear(CoreTags::posts($attachmentId));
     }
 
     /**
@@ -443,9 +427,7 @@ class Core implements Action
             return;
         }
 
-        $this->cacheTags->clear([
-            ...CoreTags::posts($objectId),
-        ]);
+        $this->cacheTags->clear(CoreTags::posts($objectId));
     }
 
     /**
@@ -516,9 +498,7 @@ class Core implements Action
             return;
         }
 
-        $this->cacheTags->clear([
-            ...CoreTags::option($option),
-        ]);
+        $this->cacheTags->clear(CoreTags::option($option));
     }
 
     /**
@@ -526,9 +506,7 @@ class Core implements Action
      */
     public function onMenuUpdate(int $menuId): void
     {
-        $this->cacheTags->clear([
-            ...CoreTags::menu($menuId),
-        ]);
+        $this->cacheTags->clear(CoreTags::menu($menuId));
     }
 
     public function onUserDelete(int $userId, ?int $reassign, WP_User $user): void

--- a/src/Actions/Core.php
+++ b/src/Actions/Core.php
@@ -13,6 +13,10 @@ use WP_User;
 
 class Core implements Action
 {
+    /** Post ids already tagged from a block this request, to avoid re-adding the
+     * same post:{id} for every inner block carrying the postId context. */
+    protected array $taggedBlockPosts = [];
+
     public function __construct(protected CacheTags $cacheTags) {}
 
     public function bind(): void
@@ -133,7 +137,8 @@ class Core implements Action
         $attributes = $block['attrs'] ?? [];
         $tags = [];
 
-        if (isset($instance->context['postId'])) {
+        if (isset($instance->context['postId']) && ! isset($this->taggedBlockPosts[$instance->context['postId']])) {
+            $this->taggedBlockPosts[$instance->context['postId']] = true;
             $tags[] = CoreTags::posts($instance->context['postId']);
         }
 

--- a/src/Actions/DebugComment.php
+++ b/src/Actions/DebugComment.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Util;
 
 class DebugComment implements Action
@@ -21,13 +22,12 @@ class DebugComment implements Action
     {
         $cacheTags = array_map(
             function ($tag) {
-                $subtag = $tag;
-                if (str_starts_with($tag, 'site:')) {
-                    [$prefix, $site, $subtag] = explode(':', $tag.':', 3);
-                }
-                [$entity, $id] = explode(':', $subtag.':');
+                // Parse to ignore any scope prefix (site:/network:) and read the
+                // underlying entity, so a scoped tag annotates like a bare one.
+                $parsed = Tag::parse($tag);
+                $id = (int) $parsed->id;
 
-                switch ($entity) {
+                switch ($parsed->type) {
                     case 'menu':
                     case 'term':
                         $term = get_term($id);
@@ -42,7 +42,7 @@ class DebugComment implements Action
                             ? sprintf('[%s] %s', $tag, esc_html($comment->comment_author))
                             : sprintf('[%s]', $tag);
                     case 'post':
-                        return sprintf('[%s] %s (%s)', $tag, esc_html(get_post($id)?->post_title ?: $id), esc_html(get_post_type($id) ?: ''));
+                        return sprintf('[%s] %s (%s)', $tag, esc_html(get_post($id)?->post_title ?: $parsed->id), esc_html(get_post_type($id) ?: ''));
                     default:
                         return sprintf('[%s]', $tag);
                 }

--- a/src/Actions/Gravityform.php
+++ b/src/Actions/Gravityform.php
@@ -36,9 +36,7 @@ class Gravityform implements Action
             return $form;
         }
 
-        $this->cacheTags->add([
-            ...GravityformTags::forms($form['id']),
-        ]);
+        $this->cacheTags->add(GravityformTags::forms($form['id']));
 
         foreach ($form['fields'] as $field) {
             // 2.9.24+ uses nonce for file uploads

--- a/src/Actions/Gravityform.php
+++ b/src/Actions/Gravityform.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\GravityformTags;
 
 class Gravityform implements Action
@@ -42,7 +43,7 @@ class Gravityform implements Action
         foreach ($form['fields'] as $field) {
             // 2.9.24+ uses nonce for file uploads
             if ($field['type'] === 'fileupload') {
-                $this->cacheTags->add(['nonce']);
+                $this->cacheTags->add([Tag::nonce()]);
             }
 
             $this->collectPrepopulateParams($field);

--- a/src/Actions/Gravityform.php
+++ b/src/Actions/Gravityform.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\NonceCron;
 use Genero\Sage\CacheTags\Tags\GravityformTags;
 
 class Gravityform implements Action
@@ -23,6 +24,10 @@ class Gravityform implements Action
         \add_filter('gform_pre_render', [$this, 'addGravityformCacheTags']);
         \add_action('gform_after_save_form', [$this, 'onSaveForm'], 10, 2);
         \add_filter('cachetags/cacheable', [$this, 'isCacheable']);
+
+        // File-upload forms tag their page 'nonce' (see addGravityformCacheTags);
+        // schedule the cron that purges those pages before the nonce expires.
+        NonceCron::register();
     }
 
     /**

--- a/src/Actions/Gravityform.php
+++ b/src/Actions/Gravityform.php
@@ -43,7 +43,7 @@ class Gravityform implements Action
         foreach ($form['fields'] as $field) {
             // 2.9.24+ uses nonce for file uploads
             if ($field['type'] === 'fileupload') {
-                $this->cacheTags->add([Tag::nonce()]);
+                $this->cacheTags->add(Tag::nonce());
             }
 
             $this->collectPrepopulateParams($field);

--- a/src/Actions/Gravityform.php
+++ b/src/Actions/Gravityform.php
@@ -4,7 +4,6 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
-use Genero\Sage\CacheTags\NonceCron;
 use Genero\Sage\CacheTags\Tags\GravityformTags;
 
 class Gravityform implements Action
@@ -24,10 +23,6 @@ class Gravityform implements Action
         \add_filter('gform_pre_render', [$this, 'addGravityformCacheTags']);
         \add_action('gform_after_save_form', [$this, 'onSaveForm'], 10, 2);
         \add_filter('cachetags/cacheable', [$this, 'isCacheable']);
-
-        // File-upload forms tag their page 'nonce' (see addGravityformCacheTags);
-        // schedule the cron that purges those pages before the nonce expires.
-        NonceCron::register();
     }
 
     /**

--- a/src/Actions/Nonce.php
+++ b/src/Actions/Nonce.php
@@ -11,10 +11,10 @@ use Genero\Sage\CacheTags\NonceCron;
  * cached page never serves an expired nonce (a form submit, AJAX action or
  * add-to-cart that then fails for everyone served that page).
  *
- * Enabled by default — it's a light twice-daily cron, and any page tagged `nonce`
- * (the Gravityform action does this for file-upload forms, but a theme can tag its
- * own) needs it without having to wire a cron by hand. Remove it from the action
- * set to opt out.
+ * Enabled by default in the shipped config — it's a light twice-daily cron, and
+ * any page tagged `nonce` (the Gravityform action does this for file-upload forms,
+ * but a theme can tag its own) needs it without having to wire a cron by hand.
+ * Remove it from the action set to opt out.
  */
 class Nonce implements Action
 {

--- a/src/Actions/Nonce.php
+++ b/src/Actions/Nonce.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Actions;
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\NonceCron;
+
+/**
+ * Schedule the WP-Cron job that purges `nonce`-tagged pages every 12 hours, so a
+ * cached page never serves an expired nonce (a form submit, AJAX action or
+ * add-to-cart that then fails for everyone served that page).
+ *
+ * Enabled by default — it's a light twice-daily cron, and any page tagged `nonce`
+ * (the Gravityform action does this for file-upload forms, but a theme can tag its
+ * own) needs it without having to wire a cron by hand. Remove it from the action
+ * set to opt out.
+ */
+class Nonce implements Action
+{
+    public function __construct(protected CacheTags $cacheTags) {}
+
+    public function bind(): void
+    {
+        NonceCron::register();
+    }
+}

--- a/src/Actions/Polylang.php
+++ b/src/Actions/Polylang.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\CoreTags;
 use Genero\Sage\CacheTags\Tags\PolylangTags;
 use WP_Post;
@@ -76,12 +77,17 @@ class Polylang implements Action
 
         $result = [];
         foreach ($tags as $tag) {
-            $parts = explode(':', $tag);
-            $isTranslatedArchive = count($parts) === 2 && $parts[0] === 'archive' && pll_is_translated_post_type($parts[1]);
+            $parsed = Tag::from($tag);
+            // Only a bare archive:{type} (no language/any qualifier, no site
+            // scope) — matching the previous count===2 string check exactly.
+            $isBareTranslatedArchive = $parsed->type === 'archive'
+                && $parsed->qualifier === null
+                && $parsed->scope === null
+                && pll_is_translated_post_type($parsed->identifier);
 
-            if ($isTranslatedArchive && $languages) {
+            if ($isBareTranslatedArchive && $languages) {
                 foreach ($languages as $language) {
-                    $result[] = "{$tag}:{$language}";
+                    $result[] = (string) $parsed->inLanguage($language);
                 }
 
                 continue;

--- a/src/Actions/Polylang.php
+++ b/src/Actions/Polylang.php
@@ -67,8 +67,8 @@ class Polylang implements Action
      * match none of the stored `archive:{type}:{lang}` entries and the
      * translated listings would never clear (the herrfors alert-banner bug).
      *
-     * @param  string[]  $tags
-     * @return string[]
+     * @param  array<string|Tag>  $tags
+     * @return Tag[]
      */
     public function filterArchiveTags(array $tags): array
     {
@@ -87,13 +87,13 @@ class Polylang implements Action
 
             if ($isBareTranslatedArchive && $languages) {
                 foreach ($languages as $language) {
-                    $result[] = (string) $parsed->qualify($language);
+                    $result[] = $parsed->qualify($language);
                 }
 
                 continue;
             }
 
-            $result[] = $tag;
+            $result[] = $parsed;
         }
 
         return $result;

--- a/src/Actions/Polylang.php
+++ b/src/Actions/Polylang.php
@@ -139,7 +139,7 @@ class Polylang implements Action
         $languages = $lang ? [$lang] : (function_exists('pll_languages_list') ? pll_languages_list() : []);
 
         foreach ($languages as $language) {
-            $this->cacheTags->clear(["archive:{$post->post_type}:{$language}"]);
+            $this->cacheTags->clear(Tag::archive($post->post_type)->qualify($language));
         }
     }
 }

--- a/src/Actions/Polylang.php
+++ b/src/Actions/Polylang.php
@@ -82,12 +82,12 @@ class Polylang implements Action
             // scope) — matching the previous count===2 string check exactly.
             $isBareTranslatedArchive = $parsed->type === 'archive'
                 && $parsed->qualifier === null
-                && $parsed->scope === null
-                && pll_is_translated_post_type($parsed->identifier);
+                && $parsed->scopes === []
+                && pll_is_translated_post_type($parsed->id);
 
             if ($isBareTranslatedArchive && $languages) {
                 foreach ($languages as $language) {
-                    $result[] = (string) $parsed->inLanguage($language);
+                    $result[] = (string) $parsed->qualify($language);
                 }
 
                 continue;

--- a/src/Actions/RestApi.php
+++ b/src/Actions/RestApi.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\CoreTags;
 use Genero\Sage\CacheTags\Util;
 use WP_Comment;
@@ -48,7 +49,7 @@ class RestApi implements Action
     /**
      * Map of collection route → listing tag, rebuilt each request.
      *
-     * @var array<string, string[]>
+     * @var array<string, Tag[]>
      */
     protected array $listingRoutes = [];
 
@@ -190,7 +191,7 @@ class RestApi implements Action
      * Cache tags for the objects a post response references (terms, author,
      * featured media), which are exposed as fields regardless of _embed.
      *
-     * @return string[]
+     * @return array<string|Tag>
      */
     protected function relatedTags(WP_Post $post, WP_REST_Request $request): array
     {
@@ -235,7 +236,7 @@ class RestApi implements Action
     /**
      * Map each REST collection route to the listing tag it should carry.
      *
-     * @return array<string, string[]>
+     * @return array<string, Tag[]>
      */
     protected function mapListingRoutes(): array
     {

--- a/src/Actions/Site.php
+++ b/src/Actions/Site.php
@@ -30,8 +30,9 @@ class Site implements Action
             function (string $tag) use ($siteId) {
                 $parsed = Tag::from($tag);
 
-                // Leave the bare site tag itself unscoped; scope everything else.
-                return $parsed->type === 'site' && $parsed->scopes === []
+                // Leave this site's own bare tag unscoped; scope everything else
+                // (incl. a custom site:foo or another site's tag flowing through).
+                return $parsed->type === 'site' && $parsed->id === $siteId && $parsed->scopes === []
                     ? $tag
                     : (string) $parsed->scope('site', $siteId);
             },

--- a/src/Actions/Site.php
+++ b/src/Actions/Site.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags\Actions;
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\SiteTags;
 
 class Site implements Action
@@ -24,13 +25,15 @@ class Site implements Action
     public function addSitePrefix(array $tags): array
     {
         $siteId = get_current_blog_id();
-        $siteTags = SiteTags::sites();
 
         return array_map(
-            function (string $tag) use ($siteId, $siteTags) {
-                return in_array($tag, $siteTags)
+            function (string $tag) use ($siteId) {
+                $parsed = Tag::from($tag);
+
+                // Leave the bare site tag itself unscoped; scope everything else.
+                return $parsed->type === 'site' && $parsed->scope === null
                     ? $tag
-                    : sprintf('site:%d:%s', $siteId, $tag);
+                    : (string) $parsed->withScope($siteId);
             },
             $tags
         );

--- a/src/Actions/Site.php
+++ b/src/Actions/Site.php
@@ -31,9 +31,9 @@ class Site implements Action
                 $parsed = Tag::from($tag);
 
                 // Leave the bare site tag itself unscoped; scope everything else.
-                return $parsed->type === 'site' && $parsed->scope === null
+                return $parsed->type === 'site' && $parsed->scopes === []
                     ? $tag
-                    : (string) $parsed->withScope($siteId);
+                    : (string) $parsed->scope('site', $siteId);
             },
             $tags
         );

--- a/src/Actions/Site.php
+++ b/src/Actions/Site.php
@@ -19,22 +19,22 @@ class Site implements Action
     }
 
     /**
-     * @param  string[]  $tags
-     * @return string[]
+     * @param  array<string|Tag>  $tags
+     * @return Tag[]
      */
     public function addSitePrefix(array $tags): array
     {
         $siteId = get_current_blog_id();
 
         return array_map(
-            function (string $tag) use ($siteId) {
+            function ($tag) use ($siteId) {
                 $parsed = Tag::from($tag);
 
                 // Leave this site's own bare tag unscoped; scope everything else
                 // (incl. a custom site:foo or another site's tag flowing through).
                 return $parsed->type === 'site' && $parsed->id === $siteId && $parsed->scopes === []
-                    ? $tag
-                    : (string) $parsed->scope('site', $siteId);
+                    ? $parsed
+                    : $parsed->scope('site', $siteId);
             },
             $tags
         );

--- a/src/Actions/Site.php
+++ b/src/Actions/Site.php
@@ -42,8 +42,6 @@ class Site implements Action
 
     public function addSiteTag(): void
     {
-        $this->cacheTags->add([
-            ...SiteTags::sites(),
-        ]);
+        $this->cacheTags->add(SiteTags::sites());
     }
 }

--- a/src/Actions/WooCommerce.php
+++ b/src/Actions/WooCommerce.php
@@ -150,9 +150,7 @@ class WooCommerce implements Action
     {
         switch (true) {
             case function_exists('is_shop') && is_shop():
-                $this->cacheTags->add([
-                    ...WooCommerceTags::shop(),
-                ]);
+                $this->cacheTags->add(WooCommerceTags::shop());
                 break;
         }
     }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -331,7 +331,7 @@ class Bootstrap
         // Fall back to the bare route if the query string overflows the url
         // column (varchar 191), matching Util::currentUrl — a silently truncated
         // URL would never match what the edge cached.
-        return strlen($full) <= apply_filters('cachetags/max-url-length', 191) ? $full : $url;
+        return strlen($full) <= Util::MAX_LENGTH ? $full : $url;
     }
 
     public function purgeCacheTags(): void

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -52,6 +52,7 @@ class Bootstrap
         protected array $actions = [Core::class],
         protected bool $nonceCron = false,
         protected bool $autoDetectActions = true,
+        protected ?string $baseTag = 'page',
     ) {
         $this->debug = $debug ?? (defined('WP_DEBUG') ? WP_DEBUG : false);
     }
@@ -135,6 +136,18 @@ class Bootstrap
     }
 
     /**
+     * Set (or disable, with null) the base tag added to every cacheable page and
+     * REST response — a single key to purge all WordPress-served pages at once
+     * (static assets, which never carry it, stay cached). Default "page".
+     */
+    public function baseTag(?string $tag): static
+    {
+        $this->baseTag = $tag;
+
+        return $this;
+    }
+
+    /**
      * Bootstrap CacheTags and return the instance.
      */
     public function bootstrap(): CacheTags
@@ -208,6 +221,12 @@ class Bootstrap
             },
             $this->withDetectedActions(array_filter($this->actions))
         );
+
+        // Always-on base tag (unless disabled with baseTag(null)) — bound with the
+        // configured tag name, so a single purge clears all WP-served pages.
+        if ($this->baseTag) {
+            $actions[] = new Actions\BaseTag($this->cacheTags, $this->baseTag);
+        }
 
         foreach ($actions as $action) {
             $this->cacheTags->bindAction($action);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -179,10 +179,10 @@ class Bootstrap
             add_filter('rest_post_dispatch', [$this, 'saveCacheTagsRest'], 10, 3);
             add_action('shutdown', [$this, 'purgeCacheTags']);
 
-            // The Gravityform action owns the nonce purge cron (it's the only
-            // producer of 'nonce' tags, from file-upload forms) and registers it in
-            // bind(). Clean up the orphaned schedule when that action isn't active.
-            if (! $this->cacheTags->hasAction(Actions\Gravityform::class)) {
+            // The Nonce action owns the nonce purge cron and registers it in
+            // bind(); clean up the orphaned schedule when it's removed from the
+            // action set (opt-out).
+            if (! $this->cacheTags->hasAction(Actions\Nonce::class)) {
                 NonceCron::unschedule();
             }
         } else {

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -117,8 +117,8 @@ class Bootstrap
     }
 
     /**
-     * Auto-enable integration actions (WooCommerce, Polylang) when their plugin
-     * is active. On by default; opt out for full manual control of the action list.
+     * Auto-enable integration actions (WooCommerce, Polylang, Gravity Forms) when
+     * their plugin is active. On by default; opt out for full manual control.
      */
     public function autoDetectActions(bool $enable = true): static
     {
@@ -156,9 +156,6 @@ class Bootstrap
             ),
         );
 
-        // Bind actions
-        $this->bindActions();
-
         // Register WP-CLI commands if available
         $this->registerWpCliCommands();
 
@@ -173,8 +170,12 @@ class Bootstrap
         // database` covers headless/network upgrades.
         add_action('admin_init', [$this, 'upgradeTable']);
 
-        // Set up WordPress hooks
+        // Bind actions and the save/purge hooks — unless disabled. Binding only
+        // when enabled keeps a disabled install fully inert; the Nonce action in
+        // particular would otherwise schedule its cron via a deferred init hook.
         if (! $this->disable) {
+            $this->bindActions();
+
             add_action('wp_footer', [$this, 'saveCacheTags']);
             add_filter('rest_post_dispatch', [$this, 'saveCacheTagsRest'], 10, 3);
             add_action('shutdown', [$this, 'purgeCacheTags']);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -50,7 +50,6 @@ class Bootstrap
         protected array $invalidators = [],
         /** @var Action[] */
         protected array $actions = [Core::class],
-        protected bool $nonceCron = false,
         protected bool $autoDetectActions = true,
         protected ?string $baseTag = 'page',
     ) {
@@ -113,13 +112,6 @@ class Bootstrap
     public function disable(bool $disable = true): static
     {
         $this->disable = $disable;
-
-        return $this;
-    }
-
-    public function nonceCron(bool $enable = true): static
-    {
-        $this->nonceCron = $enable;
 
         return $this;
     }
@@ -187,9 +179,10 @@ class Bootstrap
             add_filter('rest_post_dispatch', [$this, 'saveCacheTagsRest'], 10, 3);
             add_action('shutdown', [$this, 'purgeCacheTags']);
 
-            if ($this->nonceCron) {
-                NonceCron::register();
-            } else {
+            // The Gravityform action owns the nonce purge cron (it's the only
+            // producer of 'nonce' tags, from file-upload forms) and registers it in
+            // bind(). Clean up the orphaned schedule when that action isn't active.
+            if (! $this->cacheTags->hasAction(Actions\Gravityform::class)) {
                 NonceCron::unschedule();
             }
         } else {
@@ -234,10 +227,10 @@ class Bootstrap
     }
 
     /**
-     * Auto-enable integration actions whose plugin is active, so their safety
-     * vetoes (WooCommerce keeps cart/checkout/account out of the shared cache)
-     * and language-aware purging (Polylang) aren't silently missing when an
-     * operator forgets to list them. Toggle with autoDetectActions().
+     * Auto-enable integration actions whose plugin is active (WooCommerce,
+     * Polylang, Gravity Forms), so their safety vetoes (cart/checkout/account,
+     * prepopulated forms) and language-aware purging aren't silently missing when
+     * an operator forgets to list them. Toggle with autoDetectActions().
      *
      * @param  array<string|Action>  $actions
      * @return array<string|Action>
@@ -251,6 +244,7 @@ class Bootstrap
         $detected = array_filter([
             Actions\WooCommerce::class => class_exists('WooCommerce'),
             Actions\Polylang::class => defined('POLYLANG_VERSION'),
+            Actions\Gravityform::class => class_exists('GFForms'),
         ]);
 
         foreach (array_keys($detected) as $action) {

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -85,10 +85,9 @@ class CacheTags
      */
     public function add(array $tags): void
     {
-        $this->cacheTags = [
-            ...$this->cacheTags,
-            ...Tag::fromMany(Util::flatten($tags)),
-        ];
+        foreach (Tag::fromMany($tags) as $tag) {
+            $this->cacheTags[] = $tag;
+        }
 
         $this->boundedTags = null;
     }
@@ -105,15 +104,26 @@ class CacheTags
             return $this->boundedTags;
         }
 
-        // Validate + dedupe in string form (the canonical comparison) and run the
-        // string filter for backwards compatibility, then collapse to budget as
-        // Tags. Util::normalizeTags also re-validates the filter output so a
-        // custom tag can't smuggle a newline into the header.
-        $strings = Util::normalizeTags(Tag::toStrings($this->cacheTags));
-        $strings = apply_filters(self::FILTER_TAGS, $strings);
-        $strings = Util::normalizeTags($strings);
+        $strings = $this->resolveTags($this->cacheTags);
 
         return $this->boundedTags = Tag::toStrings($this->bound(Tag::fromMany($strings)));
+    }
+
+    /**
+     * Reduce accumulated Tags to the validated, filtered string set the store,
+     * header and invalidators consume: serialize, validate + dedupe, run the
+     * (legacy string) FILTER_TAGS filter, then re-validate its output so a custom
+     * tag can't smuggle a newline into the header.
+     *
+     * @param  Tag[]  $tags
+     * @return string[]
+     */
+    protected function resolveTags(array $tags): array
+    {
+        $strings = Util::normalizeTags(Tag::toStrings($tags));
+        $strings = apply_filters(self::FILTER_TAGS, $strings);
+
+        return Util::normalizeTags($strings);
     }
 
     /**
@@ -273,19 +283,14 @@ class CacheTags
      */
     public function clear(array $tags): void
     {
-        $this->purgeTags = [
-            ...$this->purgeTags,
-            ...Tag::fromMany(Util::flatten($tags)),
-        ];
+        foreach (Tag::fromMany($tags) as $tag) {
+            $this->purgeTags[] = $tag;
+        }
     }
 
     public function purgeQueued(): bool
     {
-        // The store and invalidators work in strings; serialize the queued Tags,
-        // run the (string) filter, and re-validate.
-        $tags = Util::normalizeTags(Tag::toStrings($this->purgeTags));
-        $tags = apply_filters(self::FILTER_TAGS, $tags);
-        $tags = Util::normalizeTags($tags);
+        $tags = $this->resolveTags($this->purgeTags);
 
         if (empty($tags)) {
             return true;

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -5,7 +5,6 @@ namespace Genero\Sage\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Action;
 use Genero\Sage\CacheTags\Contracts\Invalidator;
 use Genero\Sage\CacheTags\Contracts\Store;
-use Genero\Sage\CacheTags\Tags\CoreTags;
 use WP_Term;
 
 class CacheTags
@@ -22,12 +21,12 @@ class CacheTags
     protected static ?CacheTags $instance = null;
 
     /**
-     * @var string[]
+     * @var Tag[]
      */
     protected array $cacheTags = [];
 
     /**
-     * @var string[]
+     * @var Tag[]
      */
     protected array $purgeTags = [];
 
@@ -78,8 +77,9 @@ class CacheTags
     /**
      * Add a set of cache tags to this page load.
      *
-     * Accepts plain strings (a site's custom tags, the CoreTags builders) and/or
-     * Tag value objects; both are stored as their string form.
+     * Accepts Tag objects and/or plain strings (a site's custom tags, anything
+     * built elsewhere); strings are parsed to Tags so the rest of the pipeline
+     * works with structure.
      *
      * @param  array<string|Tag|array>  $tags
      */
@@ -87,14 +87,15 @@ class CacheTags
     {
         $this->cacheTags = [
             ...$this->cacheTags,
-            ...Tag::toStrings(Util::flatten($tags)),
+            ...Tag::fromMany(Util::flatten($tags)),
         ];
 
         $this->boundedTags = null;
     }
 
     /**
-     * Return all cache tags for this page load.
+     * Return the cache tags for this page load, as strings ready for the header
+     * and store.
      *
      * @return string[]
      */
@@ -104,14 +105,15 @@ class CacheTags
             return $this->boundedTags;
         }
 
-        $tags = Util::normalizeTags($this->cacheTags);
-        $tags = apply_filters(self::FILTER_TAGS, $tags);
+        // Validate + dedupe in string form (the canonical comparison) and run the
+        // string filter for backwards compatibility, then collapse to budget as
+        // Tags. Util::normalizeTags also re-validates the filter output so a
+        // custom tag can't smuggle a newline into the header.
+        $strings = Util::normalizeTags(Tag::toStrings($this->cacheTags));
+        $strings = apply_filters(self::FILTER_TAGS, $strings);
+        $strings = Util::normalizeTags($strings);
 
-        // Re-validate after the filter so a custom tag (e.g. one containing a
-        // newline) can't reach the Cache-Tag header.
-        $tags = Util::normalizeTags($tags);
-
-        return $this->boundedTags = $this->bound($tags);
+        return $this->boundedTags = Tag::toStrings($this->bound(Tag::fromMany($strings)));
     }
 
     /**
@@ -123,14 +125,14 @@ class CacheTags
      * taxonomy. The result over-purges rather than silently dropping tags
      * (which a provider would do on overflow, leaving stale content).
      *
-     * @param  string[]  $tags
-     * @return string[]
+     * @param  Tag[]  $tags
+     * @return Tag[]
      */
     protected function bound(array $tags): array
     {
         $limit = (int) apply_filters(self::FILTER_MAX_HEADER_BYTES, 16384);
 
-        if ($limit <= 0 || strlen(implode(' ', $tags)) <= $limit) {
+        if ($limit <= 0 || $this->headerLength($tags) <= $limit) {
             return $tags;
         }
 
@@ -138,23 +140,23 @@ class CacheTags
         $coarse = [];
 
         foreach ($tags as $tag) {
-            $collapsed = $this->collapse(Tag::parse($tag));
+            $collapsed = $this->collapse($tag);
 
             if ($collapsed === null) {
                 $kept[] = $tag;
             } else {
-                $coarse[] = (string) $collapsed;
+                $coarse[] = $collapsed;
             }
         }
 
         // Coarse collapse tags first so they survive the final trim — they keep
         // the page purgeable on any change to that post type / taxonomy.
-        $bounded = Util::normalizeTags([...$coarse, ...$kept]);
+        $bounded = $this->dedupe([...$coarse, ...$kept]);
 
         // Tags that can't be collapsed (user:, comment:, option:, …) can still
         // exceed the budget. Rather than let the provider silently drop the
         // overflow (and every key after it), trim deterministically to fit.
-        if (strlen(implode(' ', $bounded)) > $limit) {
+        if ($this->headerLength($bounded) > $limit) {
             $bounded = $this->fitToBudget($bounded, $limit);
         }
 
@@ -162,35 +164,73 @@ class CacheTags
     }
 
     /**
-     * Collapse a high-cardinality post:/term: tag to its coarse "any" form, or
+     * Collapse a high-cardinality post/term tag to its coarse "any" form, or
      * return null when it can't be collapsed (so the caller keeps it as-is).
      *
-     * Operates on the structured Tag — a multisite scope is a field carried onto
-     * the coarse tag, so there's no string parsing or prefix juggling here.
+     * Works on the structured Tag and carries its scopes onto the coarse tag, so
+     * there's no string parsing or prefix juggling here.
      */
     protected function collapse(Tag $tag): ?Tag
     {
-        if ($tag->type === 'post' && is_int($tag->identifier)) {
-            $type = get_post_type($tag->identifier);
+        $coarse = null;
 
-            return $type ? Tag::archive($type)->any()->withScope($tag->scope) : null;
+        if ($tag->type === 'post' && is_int($tag->id)) {
+            $type = get_post_type($tag->id);
+            $coarse = $type ? Tag::archive($type)->any() : null;
+        } elseif ($tag->type === 'term' && is_int($tag->id)) {
+            $term = get_term($tag->id);
+            $coarse = $term instanceof WP_Term ? Tag::taxonomy($term->taxonomy)->any() : null;
         }
 
-        if ($tag->type === 'term' && is_int($tag->identifier)) {
-            $term = get_term($tag->identifier);
-
-            return $term instanceof WP_Term ? Tag::taxonomy($term->taxonomy)->any()->withScope($tag->scope) : null;
+        if ($coarse === null) {
+            return null;
         }
 
-        return null;
+        foreach ($tag->scopes as [$dimension, $value]) {
+            $coarse = $coarse->scope($dimension, $value);
+        }
+
+        return $coarse;
+    }
+
+    /**
+     * Byte length of the space-joined header for a set of tags.
+     *
+     * @param  Tag[]  $tags
+     */
+    protected function headerLength(array $tags): int
+    {
+        return strlen(implode(' ', Tag::toStrings($tags)));
+    }
+
+    /**
+     * Remove duplicate tags (compared by their string form), preserving order.
+     *
+     * @param  Tag[]  $tags
+     * @return Tag[]
+     */
+    protected function dedupe(array $tags): array
+    {
+        $seen = [];
+        $unique = [];
+
+        foreach ($tags as $tag) {
+            $string = (string) $tag;
+            if (! isset($seen[$string])) {
+                $seen[$string] = true;
+                $unique[] = $tag;
+            }
+        }
+
+        return $unique;
     }
 
     /**
      * Trim a tag list so the space-joined header stays within $limit bytes,
      * preserving order (callers place the must-keep coarse tags first).
      *
-     * @param  string[]  $tags
-     * @return string[]
+     * @param  Tag[]  $tags
+     * @return Tag[]
      */
     protected function fitToBudget(array $tags, int $limit): array
     {
@@ -198,7 +238,7 @@ class CacheTags
         $length = 0;
 
         foreach ($tags as $tag) {
-            $length += ($fitted ? 1 : 0) + strlen($tag); // +1 for the separator
+            $length += ($fitted ? 1 : 0) + strlen((string) $tag); // +1 for the separator
             if ($length > $limit) {
                 break;
             }
@@ -235,13 +275,15 @@ class CacheTags
     {
         $this->purgeTags = [
             ...$this->purgeTags,
-            ...Tag::toStrings(Util::flatten($tags)),
+            ...Tag::fromMany(Util::flatten($tags)),
         ];
     }
 
     public function purgeQueued(): bool
     {
-        $tags = Util::normalizeTags($this->purgeTags);
+        // The store and invalidators work in strings; serialize the queued Tags,
+        // run the (string) filter, and re-validate.
+        $tags = Util::normalizeTags(Tag::toStrings($this->purgeTags));
         $tags = apply_filters(self::FILTER_TAGS, $tags);
         $tags = Util::normalizeTags($tags);
 

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -75,15 +75,19 @@ class CacheTags
     }
 
     /**
-     * Add a set of cache tags to this page load.
+     * Add cache tags to this page load.
      *
      * Accepts Tag objects and/or plain strings (a site's custom tags, anything
-     * built elsewhere); strings are parsed to Tags so the rest of the pipeline
-     * works with structure.
+     * built elsewhere) as individual arguments or arrays, nested freely — strings
+     * are parsed to Tags so the rest of the pipeline works with structure:
      *
-     * @param  array<string|Tag|array>  $tags
+     *     $cacheTags->add(Tag::post(5));
+     *     $cacheTags->add('post:5', 'term:9');
+     *     $cacheTags->add([...CoreTags::posts($ids), 'my:custom:tag']);
+     *
+     * @param  string|Tag|array<string|Tag|array>  ...$tags
      */
-    public function add(array $tags): void
+    public function add(string|Tag|array ...$tags): void
     {
         foreach (Tag::fromMany($tags) as $tag) {
             $this->cacheTags[] = $tag;
@@ -277,11 +281,12 @@ class CacheTags
     }
 
     /**
-     * Queue tags to be cleared from cache. Accepts strings and/or Tag objects.
+     * Queue tags to be cleared from cache. Accepts strings and/or Tag objects as
+     * individual arguments or arrays, nested freely (see add()).
      *
-     * @param  array<string|Tag|array>  $tags
+     * @param  string|Tag|array<string|Tag|array>  ...$tags
      */
-    public function clear(array $tags): void
+    public function clear(string|Tag|array ...$tags): void
     {
         foreach (Tag::fromMany($tags) as $tag) {
             $this->purgeTags[] = $tag;

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -316,10 +316,7 @@ class CacheTags
             $result = $this->store->clear($urls, $tags);
         }
 
-        // Let sites attach logging/metrics, and surface a failure that would
-        // otherwise be swallowed (leaving content stale at the edge).
-        do_action('cachetags/purged', $tags, $urls, $result);
-
+        // Surface a failure that would otherwise be swallowed (stale at the edge).
         if (! $result) {
             $this->logFailure(sprintf('purge failed for %d tag(s): %s', count($tags), implode(' ', array_slice($tags, 0, 20))));
         }
@@ -343,8 +340,6 @@ class CacheTags
             // Flush the tag caches only if invalidators succeeded.
             $result = $this->store->flush();
         }
-
-        do_action('cachetags/flushed', $result);
 
         if (! $result) {
             $this->logFailure('flush failed');

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -78,13 +78,16 @@ class CacheTags
     /**
      * Add a set of cache tags to this page load.
      *
-     * @param  string[]  $tags
+     * Accepts plain strings (a site's custom tags, the CoreTags builders) and/or
+     * Tag value objects; both are stored as their string form.
+     *
+     * @param  array<string|Tag|array>  $tags
      */
     public function add(array $tags): void
     {
         $this->cacheTags = [
             ...$this->cacheTags,
-            ...$tags,
+            ...Tag::toStrings(Util::flatten($tags)),
         ];
 
         $this->boundedTags = null;
@@ -135,12 +138,12 @@ class CacheTags
         $coarse = [];
 
         foreach ($tags as $tag) {
-            $collapsed = $this->collapse($tag);
+            $collapsed = $this->collapse(Tag::parse($tag));
 
             if ($collapsed === null) {
                 $kept[] = $tag;
             } else {
-                $coarse = [...$coarse, ...$collapsed];
+                $coarse[] = (string) $collapsed;
             }
         }
 
@@ -160,43 +163,26 @@ class CacheTags
 
     /**
      * Collapse a high-cardinality post:/term: tag to its coarse "any" form, or
-     * return null when it can't be collapsed (so the caller keeps it as-is). A
-     * multisite "site:N:" prefix is preserved so the coarse tag still matches
-     * what was stored.
+     * return null when it can't be collapsed (so the caller keeps it as-is).
      *
-     * @return string[]|null
+     * Operates on the structured Tag — a multisite scope is a field carried onto
+     * the coarse tag, so there's no string parsing or prefix juggling here.
      */
-    protected function collapse(string $tag): ?array
+    protected function collapse(Tag $tag): ?Tag
     {
-        [$prefix, $inner] = $this->splitSitePrefix($tag);
+        if ($tag->type === 'post' && is_int($tag->identifier)) {
+            $type = get_post_type($tag->identifier);
 
-        if (str_starts_with($inner, 'post:')) {
-            $type = get_post_type((int) substr($inner, strlen('post:')));
-
-            return $type ? $this->prefixed($prefix, CoreTags::anyArchive($type)) : null;
+            return $type ? Tag::archive($type)->any()->withScope($tag->scope) : null;
         }
 
-        if (str_starts_with($inner, 'term:')) {
-            $term = get_term((int) explode(':', $inner)[1]);
+        if ($tag->type === 'term' && is_int($tag->identifier)) {
+            $term = get_term($tag->identifier);
 
-            return $term instanceof WP_Term ? $this->prefixed($prefix, CoreTags::anyTerm($term->taxonomy)) : null;
+            return $term instanceof WP_Term ? Tag::taxonomy($term->taxonomy)->any()->withScope($tag->scope) : null;
         }
 
         return null;
-    }
-
-    /**
-     * Split an optional multisite "site:N:" prefix off the front of a tag.
-     *
-     * @return array{0: string, 1: string} [prefix, remainder]
-     */
-    protected function splitSitePrefix(string $tag): array
-    {
-        if (preg_match('/^(site:\d+:)(.*)$/', $tag, $matches)) {
-            return [$matches[1], $matches[2]];
-        }
-
-        return ['', $tag];
     }
 
     /**
@@ -223,21 +209,6 @@ class CacheTags
     }
 
     /**
-     * Re-apply a "site:N:" prefix to a set of (coarse) tags.
-     *
-     * @param  string[]  $tags
-     * @return string[]
-     */
-    protected function prefixed(string $prefix, array $tags): array
-    {
-        if ($prefix === '') {
-            return $tags;
-        }
-
-        return array_map(fn ($tag) => $prefix.$tag, $tags);
-    }
-
-    /**
      * Save current accumulated tags for current page url.
      */
     public function save(string $url): void
@@ -256,15 +227,15 @@ class CacheTags
     }
 
     /**
-     * Queue tags to be cleared from cache.
+     * Queue tags to be cleared from cache. Accepts strings and/or Tag objects.
      *
-     * @param  string[]  $tags
+     * @param  array<string|Tag|array>  $tags
      */
     public function clear(array $tags): void
     {
         $this->purgeTags = [
             ...$this->purgeTags,
-            ...$tags,
+            ...Tag::toStrings(Util::flatten($tags)),
         ];
     }
 

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -108,26 +108,27 @@ class CacheTags
             return $this->boundedTags;
         }
 
-        $strings = $this->resolveTags($this->cacheTags);
-
-        return $this->boundedTags = Tag::toStrings($this->bound(Tag::fromMany($strings)));
+        return $this->boundedTags = Tag::toStrings($this->bound($this->resolveTags($this->cacheTags)));
     }
 
     /**
-     * Reduce accumulated Tags to the validated, filtered string set the store,
-     * header and invalidators consume: serialize, validate + dedupe, run the
-     * (legacy string) FILTER_TAGS filter, then re-validate its output so a custom
-     * tag can't smuggle a newline into the header.
+     * Apply the FILTER_TAGS transforms — the Site prefix and Polylang language
+     * variants — to the accumulated Tags, drop any whose serialized form isn't a
+     * header-safe token, and dedupe. Tags stay structured throughout; only the
+     * header/store/invalidator edges serialize them.
      *
      * @param  Tag[]  $tags
-     * @return string[]
+     * @return Tag[]
      */
     protected function resolveTags(array $tags): array
     {
-        $strings = Util::normalizeTags(Tag::toStrings($tags));
-        $strings = apply_filters(self::FILTER_TAGS, $strings);
+        // fromMany tolerates a filter that returns strings or nested arrays.
+        $tags = Tag::fromMany(apply_filters(self::FILTER_TAGS, $tags));
 
-        return Util::normalizeTags($strings);
+        return $this->dedupe(array_values(array_filter(
+            $tags,
+            fn ($tag) => Util::isValidTag((string) $tag)
+        )));
     }
 
     /**
@@ -295,7 +296,7 @@ class CacheTags
 
     public function purgeQueued(): bool
     {
-        $tags = $this->resolveTags($this->purgeTags);
+        $tags = Tag::toStrings($this->resolveTags($this->purgeTags));
 
         if (empty($tags)) {
             return true;

--- a/src/CacheTagsServiceProvider.php
+++ b/src/CacheTagsServiceProvider.php
@@ -48,7 +48,6 @@ class CacheTagsServiceProvider extends ServiceProvider
             store: $config->get('cachetags.store', WordpressDbStore::class),
             invalidators: $config->get('cachetags.invalidator', []),
             actions: $config->get('cachetags.action', []),
-            nonceCron: $config->get('cachetags.nonce-cron', false),
             autoDetectActions: $config->get('cachetags.auto-detect-actions', true),
             baseTag: $config->get('cachetags.base-tag', 'page'),
         );

--- a/src/CacheTagsServiceProvider.php
+++ b/src/CacheTagsServiceProvider.php
@@ -50,6 +50,7 @@ class CacheTagsServiceProvider extends ServiceProvider
             actions: $config->get('cachetags.action', []),
             nonceCron: $config->get('cachetags.nonce-cron', false),
             autoDetectActions: $config->get('cachetags.auto-detect-actions', true),
+            baseTag: $config->get('cachetags.base-tag', 'page'),
         );
 
         return $bootstrap;

--- a/src/Invalidators/FastlyCacheInvalidator.php
+++ b/src/Invalidators/FastlyCacheInvalidator.php
@@ -17,11 +17,18 @@ class FastlyCacheInvalidator implements Invalidator
     const FASTLY_BASE_URL = 'https://api.fastly.com/service/';
 
     /**
-     * Fastly's bulk surrogate-key purge accepts at most 256 keys per request;
-     * a larger payload is rejected (and the purge silently fails). Bulk edits or
-     * a multisite flush can exceed this, so keys are chunked.
+     * Fastly's bulk surrogate-key purge accepts at most 256 keys per request; a
+     * larger payload is rejected wholesale with HTTP 400. Bulk edits or a
+     * multisite flush can exceed this, so keys are chunked.
      */
     const MAX_KEYS_PER_PURGE = 256;
+
+    /**
+     * Cap how many chunk purges fan out at once. Fastly's purge budget is ~100k/h
+     * (~27/s); firing hundreds of requests in one burst risks 429s and exhausts
+     * local connection handles for no gain. Windows of this size keep it bounded.
+     */
+    const MAX_CONCURRENT_PURGES = 10;
 
     protected ?string $serviceId;
 
@@ -82,11 +89,14 @@ class FastlyCacheInvalidator implements Invalidator
      */
     protected function dispatchParallel(array $requests): bool
     {
-        $responses = Requests::request_multiple($requests, ['timeout' => 5, 'verify' => false]);
+        // Bounded fan-out: at most MAX_CONCURRENT_PURGES in flight per window.
+        foreach (array_chunk($requests, self::MAX_CONCURRENT_PURGES) as $window) {
+            $responses = Requests::request_multiple($window, ['timeout' => 5]);
 
-        foreach ($responses as $response) {
-            if (! $response instanceof Response || $response->status_code !== 200) {
-                return false;
+            foreach ($responses as $response) {
+                if (! $response instanceof Response || $response->status_code !== 200) {
+                    return false;
+                }
             }
         }
 
@@ -147,7 +157,6 @@ class FastlyCacheInvalidator implements Invalidator
                 // 'fastly-soft-purge' => '1',
                 'Accept' => 'application/json',
             ],
-            'sslverify' => false,
             'timeout' => 5,
         ];
 

--- a/src/Invalidators/FastlyCacheInvalidator.php
+++ b/src/Invalidators/FastlyCacheInvalidator.php
@@ -9,6 +9,7 @@ use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\SiteTags;
 use Genero\Sage\CacheTags\Util;
 use WP_Error;
+use WpOrg\Requests\Exception;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
 
@@ -29,6 +30,12 @@ class FastlyCacheInvalidator implements Invalidator
      * local connection handles for no gain. Windows of this size keep it bounded.
      */
     const MAX_CONCURRENT_PURGES = 10;
+
+    /** Retry a rate-limited (429) purge this many times before giving up. */
+    const MAX_PURGE_RETRIES = 2;
+
+    /** Cap the 429 backoff so a shutdown-time purge can't hang for minutes. */
+    const MAX_BACKOFF_SECONDS = 10;
 
     protected ?string $serviceId;
 
@@ -91,16 +98,71 @@ class FastlyCacheInvalidator implements Invalidator
     {
         // Bounded fan-out: at most MAX_CONCURRENT_PURGES in flight per window.
         foreach (array_chunk($requests, self::MAX_CONCURRENT_PURGES) as $window) {
-            $responses = Requests::request_multiple($window, ['timeout' => 5]);
+            $pending = array_values($window);
 
-            foreach ($responses as $response) {
-                if (! $response instanceof Response || $response->status_code !== 200) {
+            for ($attempt = 0; ; $attempt++) {
+                $responses = $this->requestMultiple($pending);
+                $retry = [];
+                $reset = '';
+
+                foreach ($responses as $i => $response) {
+                    if ($response instanceof Response && $response->status_code === 200) {
+                        continue;
+                    }
+
+                    // Retry only the rate-limited chunks (re-sending the rest would
+                    // just spend more of the purge budget). Other failures are fatal.
+                    if ($response instanceof Response && $response->status_code === 429 && $attempt < self::MAX_PURGE_RETRIES) {
+                        $retry[] = $pending[$i];
+                        $reset = (string) ($response->headers['fastly-ratelimit-reset'] ?? $reset);
+
+                        continue;
+                    }
+
                     return false;
                 }
+
+                if ($retry === []) {
+                    break;
+                }
+
+                $this->pauseBeforeRetry($this->backoffSeconds($reset));
+                $pending = $retry;
             }
         }
 
         return true;
+    }
+
+    /**
+     * Real concurrent dispatch — isolated as a seam so the retry/window logic can
+     * be tested without real HTTP.
+     *
+     * @param  array<int, array<string, mixed>>  $requests
+     * @return array<int, Response|Exception>
+     */
+    protected function requestMultiple(array $requests): array
+    {
+        return Requests::request_multiple($requests, ['timeout' => 5]);
+    }
+
+    /**
+     * Seconds to wait before retrying a 429. Fastly sends no Retry-After, only
+     * Fastly-RateLimit-Reset (a Unix timestamp); honour it, but cap the wait so a
+     * purge running on shutdown can't hang for minutes, and floor it at 1s.
+     */
+    protected function backoffSeconds(string $reset): int
+    {
+        $reset = (int) $reset;
+        $wait = $reset > 0 ? $reset - time() : 1;
+
+        return max(1, min(self::MAX_BACKOFF_SECONDS, $wait));
+    }
+
+    /** Seam so tests don't actually sleep. */
+    protected function pauseBeforeRetry(int $seconds): void
+    {
+        sleep($seconds);
     }
 
     public function flush(): bool
@@ -132,18 +194,31 @@ class FastlyCacheInvalidator implements Invalidator
     protected function apiCall(string $path, ?array $payload = null): true|WP_Error
     {
         $url = self::FASTLY_BASE_URL.$this->serviceId.$path;
-        $result = wp_remote_post($url, $this->buildRequest($payload));
-        if (is_wp_error($result)) {
-            return $result;
-        }
-        $responseCode = wp_remote_retrieve_response_code($result);
-        if ($responseCode === 200) {
-            return true;
-        }
 
-        $response = json_decode(wp_remote_retrieve_body($result));
+        for ($attempt = 0; ; $attempt++) {
+            $result = wp_remote_post($url, $this->buildRequest($payload));
+            if (is_wp_error($result)) {
+                return $result;
+            }
 
-        return new WP_Error('fastly_error', $response->msg ?? 'Unknown', $response->detail ?? '');
+            $responseCode = wp_remote_retrieve_response_code($result);
+            if ($responseCode === 200) {
+                return true;
+            }
+
+            // Rate-limited: back off against Fastly-RateLimit-Reset and retry.
+            if ($responseCode === 429 && $attempt < self::MAX_PURGE_RETRIES) {
+                $this->pauseBeforeRetry($this->backoffSeconds(
+                    (string) wp_remote_retrieve_header($result, 'fastly-ratelimit-reset')
+                ));
+
+                continue;
+            }
+
+            $response = json_decode(wp_remote_retrieve_body($result));
+
+            return new WP_Error('fastly_error', $response->msg ?? 'Unknown', $response->detail ?? '');
+        }
     }
 
     /**

--- a/src/Invalidators/FastlyCacheInvalidator.php
+++ b/src/Invalidators/FastlyCacheInvalidator.php
@@ -5,6 +5,7 @@ namespace Genero\Sage\CacheTags\Invalidators;
 use Genero\Sage\CacheTags\Actions\Site;
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Invalidator;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\SiteTags;
 use Genero\Sage\CacheTags\Util;
 use WP_Error;
@@ -95,7 +96,7 @@ class FastlyCacheInvalidator implements Invalidator
     public function flush(): bool
     {
         if ($this->hasAction(Site::class)) {
-            $tags = SiteTags::sites('any');
+            $tags = Tag::toStrings(SiteTags::sites('any'));
 
             return $this->clear($tags, $tags);
         } else {

--- a/src/Invalidators/FastlyCacheInvalidator.php
+++ b/src/Invalidators/FastlyCacheInvalidator.php
@@ -103,6 +103,7 @@ class FastlyCacheInvalidator implements Invalidator
             for ($attempt = 0; ; $attempt++) {
                 $responses = $this->requestMultiple($pending);
                 $retry = [];
+                $retryAfter = '';
                 $reset = '';
 
                 foreach ($responses as $i => $response) {
@@ -114,6 +115,7 @@ class FastlyCacheInvalidator implements Invalidator
                     // just spend more of the purge budget). Other failures are fatal.
                     if ($response instanceof Response && $response->status_code === 429 && $attempt < self::MAX_PURGE_RETRIES) {
                         $retry[] = $pending[$i];
+                        $retryAfter = (string) ($response->headers['retry-after'] ?? $retryAfter);
                         $reset = (string) ($response->headers['fastly-ratelimit-reset'] ?? $reset);
 
                         continue;
@@ -126,7 +128,7 @@ class FastlyCacheInvalidator implements Invalidator
                     break;
                 }
 
-                $this->pauseBeforeRetry($this->backoffSeconds($reset));
+                $this->pauseBeforeRetry($this->backoffSeconds($retryAfter, $reset, $attempt));
                 $pending = $retry;
             }
         }
@@ -147,16 +149,24 @@ class FastlyCacheInvalidator implements Invalidator
     }
 
     /**
-     * Seconds to wait before retrying a 429. Fastly sends no Retry-After, only
-     * Fastly-RateLimit-Reset (a Unix timestamp); honour it, but cap the wait so a
-     * purge running on shutdown can't hang for minutes, and floor it at 1s.
+     * Seconds to wait before retrying a 429. Fastly's purge limit is a separate
+     * bucket from the API limit and isn't documented to return a timing header at
+     * all, so try, in order: Retry-After (defensive — Fastly doesn't document it,
+     * but a proxy might add it; delta-seconds or HTTP-date), then the documented
+     * Fastly-RateLimit-Reset (a Unix timestamp), then plain exponential backoff.
+     * The wait is capped so a purge running on shutdown can't hang, floored at 1s.
      */
-    protected function backoffSeconds(string $reset): int
+    protected function backoffSeconds(string $retryAfter, string $reset, int $attempt): int
     {
-        $reset = (int) $reset;
-        $wait = $reset > 0 ? $reset - time() : 1;
+        if ($retryAfter !== '') {
+            $wait = is_numeric($retryAfter) ? (int) $retryAfter : (strtotime($retryAfter) ?: time()) - time();
+        } elseif ((int) $reset > 0) {
+            $wait = (int) $reset - time();
+        } else {
+            $wait = 2 ** $attempt; // 1s, 2s, 4s, …
+        }
 
-        return max(1, min(self::MAX_BACKOFF_SECONDS, $wait));
+        return max(1, min(self::MAX_BACKOFF_SECONDS, (int) $wait));
     }
 
     /** Seam so tests don't actually sleep. */
@@ -206,10 +216,13 @@ class FastlyCacheInvalidator implements Invalidator
                 return true;
             }
 
-            // Rate-limited: back off against Fastly-RateLimit-Reset and retry.
+            // Rate-limited: back off (Retry-After / Fastly-RateLimit-Reset /
+            // exponential) and retry.
             if ($responseCode === 429 && $attempt < self::MAX_PURGE_RETRIES) {
                 $this->pauseBeforeRetry($this->backoffSeconds(
-                    (string) wp_remote_retrieve_header($result, 'fastly-ratelimit-reset')
+                    (string) wp_remote_retrieve_header($result, 'retry-after'),
+                    (string) wp_remote_retrieve_header($result, 'fastly-ratelimit-reset'),
+                    $attempt,
                 ));
 
                 continue;

--- a/src/Invalidators/FastlyCacheInvalidator.php
+++ b/src/Invalidators/FastlyCacheInvalidator.php
@@ -8,6 +8,8 @@ use Genero\Sage\CacheTags\Contracts\Invalidator;
 use Genero\Sage\CacheTags\Tags\SiteTags;
 use Genero\Sage\CacheTags\Util;
 use WP_Error;
+use WpOrg\Requests\Requests;
+use WpOrg\Requests\Response;
 
 class FastlyCacheInvalidator implements Invalidator
 {
@@ -32,17 +34,62 @@ class FastlyCacheInvalidator implements Invalidator
 
     public function clear(array $urls, array $tags): bool
     {
-        $ok = true;
+        $chunks = array_chunk($tags, self::MAX_KEYS_PER_PURGE);
 
-        foreach (array_chunk($tags, self::MAX_KEYS_PER_PURGE) as $chunk) {
-            $response = $this->apiCall('/purge/', [
-                'surrogate_keys' => array_values($chunk),
-            ]);
-
-            $ok = ! is_wp_error($response) && $ok;
+        if ($chunks === []) {
+            return true;
         }
 
-        return $ok;
+        // One request — the overwhelmingly common case — stays a simple blocking
+        // call (and goes through the WP HTTP API).
+        if (count($chunks) === 1) {
+            return ! is_wp_error($this->apiCall('/purge/', ['surrogate_keys' => array_values($chunks[0])]));
+        }
+
+        // Bulk (>256 keys): fan the chunks out concurrently rather than make N
+        // sequential blocking round-trips.
+        return $this->purgeChunksInParallel($chunks);
+    }
+
+    /**
+     * @param  array<int, string[]>  $chunks
+     */
+    protected function purgeChunksInParallel(array $chunks): bool
+    {
+        $url = self::FASTLY_BASE_URL.$this->serviceId.'/purge/';
+
+        $requests = array_map(function (array $chunk) use ($url) {
+            // Reuse buildRequest so the soft-purge subclass's header carries over.
+            $args = $this->buildRequest(['surrogate_keys' => array_values($chunk)]);
+
+            return [
+                'url' => $url,
+                'type' => Requests::POST,
+                'headers' => $args['headers'],
+                'data' => $args['body'],
+            ];
+        }, $chunks);
+
+        return $this->dispatchParallel($requests);
+    }
+
+    /**
+     * Send prepared requests concurrently; true only if every purge returns 200.
+     * Isolated as a seam so the chunking can be asserted without real HTTP.
+     *
+     * @param  array<int, array<string, mixed>>  $requests
+     */
+    protected function dispatchParallel(array $requests): bool
+    {
+        $responses = Requests::request_multiple($requests, ['timeout' => 5, 'verify' => false]);
+
+        foreach ($responses as $response) {
+            if (! $response instanceof Response || $response->status_code !== 200) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function flush(): bool

--- a/src/Invalidators/KinstaCacheInvalidator.php
+++ b/src/Invalidators/KinstaCacheInvalidator.php
@@ -87,9 +87,34 @@ class KinstaCacheInvalidator implements Invalidator
 
         curl_exec($request);
         $errorCode = curl_errno($request);
+        $errorMessage = curl_error($request);
         $responseCode = curl_getinfo($request, CURLINFO_HTTP_CODE);
 
-        return $errorCode === 0 && $responseCode === 200;
+        if ($errorCode !== 0 || $responseCode !== 200) {
+            // The MU-plugin endpoint normally answers 200 on accept; a non-200 (or
+            // a cURL error) is the only client-side signal of endpoint backpressure
+            // or trouble, so surface it instead of failing silently. Downstream
+            // edge (Cloudflare) throttling stays invisible — the purge is dispatched
+            // asynchronously after this returns.
+            $this->logPurgeFailure($endpoint, $responseCode, $errorCode, $errorMessage);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Log a failed purge POST. A seam so it can be asserted without scraping logs.
+     */
+    protected function logPurgeFailure(string $endpoint, int $status, int $errno, string $error): void
+    {
+        error_log(sprintf(
+            '[sage-cachetags] Kinsta purge to %s failed: HTTP %d%s',
+            $endpoint,
+            $status,
+            $errno !== 0 ? " (cURL {$errno}: {$error})" : '',
+        ));
     }
 
     public function flush(): bool

--- a/src/Invalidators/KinstaCacheInvalidator.php
+++ b/src/Invalidators/KinstaCacheInvalidator.php
@@ -9,9 +9,17 @@ class KinstaCacheInvalidator implements Invalidator
 {
     const IMMEDIATE_PATH = 'https://localhost/kinsta-clear-cache/v2/immediate';
 
+    // Kinsta's throttled endpoint coalesces and rate-smooths purges server-side;
+    // its MU-plugin routes high-cardinality URLs here rather than to immediate.
+    const THROTTLED_PATH = 'https://localhost/kinsta-clear-cache/v2/throttled';
+
     const CLEAR_ALL_PATH = 'https://localhost/kinsta-clear-cache-all';
 
     const POST_MAX_BODY_SIZE = 51200;
+
+    // Above this many chunks a purge is "bulk" and routes to the throttled
+    // endpoint instead of immediate (and never to a full-site flush).
+    const IMMEDIATE_MAX_REQUESTS = 3;
 
     /**
      * @param  string[]  $urls
@@ -25,13 +33,18 @@ class KinstaCacheInvalidator implements Invalidator
 
         $requests = Util::chunkRequest($this->purgeList($urls), self::POST_MAX_BODY_SIZE);
 
-        if (count($requests) > 3) {
-            return $this->flush();
-        }
+        // A small purge goes to the immediate endpoint so the edit is live at
+        // once. A bulk purge goes to Kinsta's throttled endpoint, which coalesces
+        // and rate-smooths server-side — far better than escalating to a full-site
+        // flush, which is rate-limited (1 per 10s) and leaves every page cold for
+        // minutes (an origin stampede on exactly the busy sites that hit it).
+        $endpoint = count($requests) > self::IMMEDIATE_MAX_REQUESTS
+            ? self::THROTTLED_PATH
+            : self::IMMEDIATE_PATH;
 
         return array_reduce(
             $requests,
-            fn (bool $result, string $chunk) => $this->post(self::IMMEDIATE_PATH, $chunk) ? $result : false,
+            fn (bool $result, string $chunk) => $this->post($endpoint, $chunk) ? $result : false,
             true
         );
     }

--- a/src/NonceCron.php
+++ b/src/NonceCron.php
@@ -43,7 +43,7 @@ class NonceCron
         if ($cacheTags === null) {
             return;
         }
-        $cacheTags->clear([Tag::nonce()]);
+        $cacheTags->clear(Tag::nonce());
         $cacheTags->purgeQueued();
     }
 }

--- a/src/NonceCron.php
+++ b/src/NonceCron.php
@@ -43,7 +43,7 @@ class NonceCron
         if ($cacheTags === null) {
             return;
         }
-        $cacheTags->clear(['nonce']);
+        $cacheTags->clear([Tag::nonce()]);
         $cacheTags->purgeQueued();
     }
 }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -3,35 +3,43 @@
 namespace Genero\Sage\CacheTags;
 
 /**
- * A cache tag as structured data.
+ * A cache tag as structured, immutable data with a fluent builder.
  *
- * Tags are strings at every boundary (the Cache-Tag header, the store, the
- * invalidators, the cachetags/filter-tags filter, custom code calling add()),
- * but reasoning about them — applying a multisite scope or a language, or
- * collapsing a high-cardinality tag to its coarse form — is cleaner on fields
- * than on strings. This object is that structured form; parse() and __toString()
- * are the single place a tag string is read or written, so the rest of the
- * codebase never parses tags.
+ * The codebase passes Tags around, not strings; a tag is only turned into a
+ * string at a true boundary (the Cache-Tag header, the store, an HTTP purge),
+ * and a string only becomes a Tag when one comes in (a site's custom tag, the
+ * cachetags/filter-tags filter). parse() and __toString() are the single place
+ * that conversion happens.
  *
- * Unrecognised strings (a site's own custom tags) round-trip exactly via the
- * `raw` field, so the structured model is fully backwards compatible.
+ * Context is expressed with two general operations rather than purpose-built
+ * methods, so new dimensions (a multisite network, a tenant, …) need no new API:
+ *
+ *   Tag::post(5)                         // post:5
+ *   Tag::archive('post')->any()          // archive:post:any
+ *   Tag::term(9)->full()                 // term:9:full
+ *   Tag::post(5)->scope('site', 5)       // site:5:post:5
+ *   Tag::post(5)->scope('network', 2)->scope('site', 5)  // network:2:site:5:post:5
+ *   Tag::archive('post')->qualify($lang) // archive:post:fi
+ *   Tag::of('gform', 5)                  // an arbitrary type
+ *
+ * Unrecognised strings round-trip verbatim, so custom tags are fully supported.
  */
 final class Tag implements \Stringable
 {
-    /** Tag types whose identifier is a numeric id. */
-    const NUMERIC_TYPES = ['post', 'term', 'user', 'comment', 'menu', 'gform', 'site'];
+    /**
+     * Leading "dimension:value" pairs treated as scope when reading a string,
+     * outermost first. Extend this as new scoping dimensions appear.
+     */
+    const SCOPE_DIMENSIONS = ['network', 'site'];
 
-    /** Tag types whose identifier is a name/slug. */
-    const NAMED_TYPES = ['archive', 'taxonomy', 'role', 'option', 'lang'];
-
-    /** Tag types with no identifier. */
-    const BARE_TYPES = ['nonce'];
-
+    /**
+     * @param  list<array{0: string, 1: int|string}>  $scopes  outer → inner
+     */
     private function __construct(
         public readonly string $type,
-        public readonly int|string|null $identifier = null,
+        public readonly int|string|null $id = null,
         public readonly ?string $qualifier = null,
-        public readonly ?int $scope = null,
+        public readonly array $scopes = [],
         public readonly ?string $raw = null,
     ) {}
 
@@ -60,7 +68,7 @@ final class Tag implements \Stringable
         return new self('menu', $id);
     }
 
-    public static function gform(int $id): self
+    public static function form(int $id): self
     {
         return new self('gform', $id);
     }
@@ -70,19 +78,19 @@ final class Tag implements \Stringable
         return new self('site', $id);
     }
 
-    public static function archive(string $name): self
+    public static function archive(string $postType): self
     {
-        return new self('archive', $name);
+        return new self('archive', $postType);
     }
 
-    public static function taxonomy(string $name): self
+    public static function taxonomy(string $taxonomy): self
     {
-        return new self('taxonomy', $name);
+        return new self('taxonomy', $taxonomy);
     }
 
-    public static function role(string $name): self
+    public static function role(string $role): self
     {
-        return new self('role', $name);
+        return new self('role', $role);
     }
 
     public static function option(string $name): self
@@ -101,12 +109,12 @@ final class Tag implements \Stringable
     }
 
     /**
-     * A tag whose string form isn't part of the known grammar (a site's custom
-     * tag). Carried verbatim so it round-trips exactly.
+     * Build a tag of an arbitrary type — the escape hatch for tags outside the
+     * named vocabulary (a custom integration's tags).
      */
-    public static function raw(string $literal): self
+    public static function of(string $type, int|string|null $id = null): self
     {
-        return new self('', null, null, null, $literal);
+        return new self($type, $id);
     }
 
     /**
@@ -119,29 +127,33 @@ final class Tag implements \Stringable
         return $tag instanceof self ? $tag : self::parse((string) $tag);
     }
 
+    /** Coarse "any of this type" form, e.g. archive:post:any. */
     public function any(): self
     {
-        return $this->withQualifier('any');
+        return $this->qualify('any');
     }
 
+    /** The "full"/pages qualifier, e.g. term:9:full. */
     public function full(): self
     {
-        return $this->withQualifier('full');
+        return $this->qualify('full');
     }
 
-    public function inLanguage(string $lang): self
+    /**
+     * Set the qualifier — the general trailing variant (any, full, a language, …).
+     */
+    public function qualify(string $qualifier): self
     {
-        return $this->withQualifier($lang);
+        return new self($this->type, $this->id, $qualifier, $this->scopes, $this->raw);
     }
 
-    public function withQualifier(?string $qualifier): self
+    /**
+     * Nest the tag under a scope dimension. Composable for any number of
+     * dimensions; the first scope() is the outermost.
+     */
+    public function scope(string $dimension, int|string $value): self
     {
-        return new self($this->type, $this->identifier, $qualifier, $this->scope, $this->raw);
-    }
-
-    public function withScope(?int $scope): self
-    {
-        return new self($this->type, $this->identifier, $this->qualifier, $scope, $this->raw);
+        return new self($this->type, $this->id, $this->qualifier, [...$this->scopes, [$dimension, $value]], $this->raw);
     }
 
     public function isRaw(): bool
@@ -151,49 +163,53 @@ final class Tag implements \Stringable
 
     public function __toString(): string
     {
+        $prefix = '';
+        foreach ($this->scopes as [$dimension, $value]) {
+            $prefix .= "{$dimension}:{$value}:";
+        }
+
         $body = $this->isRaw()
             ? $this->raw
             : $this->type
-                .($this->identifier !== null ? ":{$this->identifier}" : '')
+                .($this->id !== null ? ":{$this->id}" : '')
                 .($this->qualifier !== null ? ":{$this->qualifier}" : '');
 
-        return $this->scope !== null ? "site:{$this->scope}:{$body}" : $body;
+        return $prefix.$body;
     }
 
     /**
-     * Read a tag string into structure. The one place a tag string is parsed —
-     * including peeling off an optional multisite "site:N:" scope prefix.
+     * Read a tag string into structure — the one place a tag string is parsed,
+     * including peeling off leading scope dimensions.
      */
     public static function parse(string $tag): self
     {
-        $scope = null;
-        if (preg_match('/^site:(\d+):(.+)$/', $tag, $matches)) {
-            $scope = (int) $matches[1];
-            $tag = $matches[2];
+        $scopes = [];
+        $segments = explode(':', $tag);
+
+        // Peel leading "dimension:value" scope pairs while a body remains after
+        // them, so a bare "site:5" stays a tag but "site:5:post:3" is scoped.
+        while (count($segments) > 2 && in_array($segments[0], self::SCOPE_DIMENSIONS, true)) {
+            $dimension = array_shift($segments);
+            $value = array_shift($segments);
+            $scopes[] = [$dimension, ctype_digit($value) ? (int) $value : $value];
         }
 
-        $parts = explode(':', $tag);
-        $type = $parts[0];
+        $type = $segments[0];
+        $id = $segments[1] ?? null;
+        $qualifier = $segments[2] ?? null;
 
-        // A bare "site:N" tag (the scope tag itself, not a prefix).
-        if ($type === 'site' && $scope === null && count($parts) === 2 && ctype_digit($parts[1])) {
-            return new self('site', (int) $parts[1]);
+        // A clean type:id(:qualifier) shape (≤ 3 segments) maps to fields; numeric
+        // ids become ints. Anything else is kept verbatim as a raw tag.
+        if ($type !== '' && count($segments) <= 3) {
+            return new self(
+                $type,
+                $id !== null && ctype_digit($id) ? (int) $id : $id,
+                $qualifier,
+                $scopes,
+            );
         }
 
-        if (in_array($type, self::NUMERIC_TYPES, true) && isset($parts[1]) && ctype_digit($parts[1])) {
-            return new self($type, (int) $parts[1], $parts[2] ?? null, $scope);
-        }
-
-        if (in_array($type, self::NAMED_TYPES, true) && isset($parts[1]) && $parts[1] !== '') {
-            return new self($type, $parts[1], $parts[2] ?? null, $scope);
-        }
-
-        if (in_array($type, self::BARE_TYPES, true) && count($parts) === 1) {
-            return new self($type, null, null, $scope);
-        }
-
-        // Unknown shape — keep the literal so custom tags round-trip exactly.
-        return new self('', null, null, $scope, $tag);
+        return new self('', null, null, $scopes, implode(':', $segments));
     }
 
     /**

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Genero\Sage\CacheTags;
+
+/**
+ * A cache tag as structured data.
+ *
+ * Tags are strings at every boundary (the Cache-Tag header, the store, the
+ * invalidators, the cachetags/filter-tags filter, custom code calling add()),
+ * but reasoning about them — applying a multisite scope or a language, or
+ * collapsing a high-cardinality tag to its coarse form — is cleaner on fields
+ * than on strings. This object is that structured form; parse() and __toString()
+ * are the single place a tag string is read or written, so the rest of the
+ * codebase never parses tags.
+ *
+ * Unrecognised strings (a site's own custom tags) round-trip exactly via the
+ * `raw` field, so the structured model is fully backwards compatible.
+ */
+final class Tag implements \Stringable
+{
+    /** Tag types whose identifier is a numeric id. */
+    const NUMERIC_TYPES = ['post', 'term', 'user', 'comment', 'menu', 'gform', 'site'];
+
+    /** Tag types whose identifier is a name/slug. */
+    const NAMED_TYPES = ['archive', 'taxonomy', 'role', 'option', 'lang'];
+
+    /** Tag types with no identifier. */
+    const BARE_TYPES = ['nonce'];
+
+    private function __construct(
+        public readonly string $type,
+        public readonly int|string|null $identifier = null,
+        public readonly ?string $qualifier = null,
+        public readonly ?int $scope = null,
+        public readonly ?string $raw = null,
+    ) {}
+
+    public static function post(int $id): self
+    {
+        return new self('post', $id);
+    }
+
+    public static function term(int $id): self
+    {
+        return new self('term', $id);
+    }
+
+    public static function user(int $id): self
+    {
+        return new self('user', $id);
+    }
+
+    public static function comment(int $id): self
+    {
+        return new self('comment', $id);
+    }
+
+    public static function menu(int $id): self
+    {
+        return new self('menu', $id);
+    }
+
+    public static function gform(int $id): self
+    {
+        return new self('gform', $id);
+    }
+
+    public static function site(int $id): self
+    {
+        return new self('site', $id);
+    }
+
+    public static function archive(string $name): self
+    {
+        return new self('archive', $name);
+    }
+
+    public static function taxonomy(string $name): self
+    {
+        return new self('taxonomy', $name);
+    }
+
+    public static function role(string $name): self
+    {
+        return new self('role', $name);
+    }
+
+    public static function option(string $name): self
+    {
+        return new self('option', $name);
+    }
+
+    public static function language(string $slug): self
+    {
+        return new self('lang', $slug);
+    }
+
+    public static function nonce(): self
+    {
+        return new self('nonce');
+    }
+
+    /**
+     * A tag whose string form isn't part of the known grammar (a site's custom
+     * tag). Carried verbatim so it round-trips exactly.
+     */
+    public static function raw(string $literal): self
+    {
+        return new self('', null, null, null, $literal);
+    }
+
+    /**
+     * Normalise a string or Tag to a Tag.
+     *
+     * @param  string|Tag  $tag
+     */
+    public static function from($tag): self
+    {
+        return $tag instanceof self ? $tag : self::parse((string) $tag);
+    }
+
+    public function any(): self
+    {
+        return $this->withQualifier('any');
+    }
+
+    public function full(): self
+    {
+        return $this->withQualifier('full');
+    }
+
+    public function inLanguage(string $lang): self
+    {
+        return $this->withQualifier($lang);
+    }
+
+    public function withQualifier(?string $qualifier): self
+    {
+        return new self($this->type, $this->identifier, $qualifier, $this->scope, $this->raw);
+    }
+
+    public function withScope(?int $scope): self
+    {
+        return new self($this->type, $this->identifier, $this->qualifier, $scope, $this->raw);
+    }
+
+    public function isRaw(): bool
+    {
+        return $this->raw !== null;
+    }
+
+    public function __toString(): string
+    {
+        $body = $this->isRaw()
+            ? $this->raw
+            : $this->type
+                .($this->identifier !== null ? ":{$this->identifier}" : '')
+                .($this->qualifier !== null ? ":{$this->qualifier}" : '');
+
+        return $this->scope !== null ? "site:{$this->scope}:{$body}" : $body;
+    }
+
+    /**
+     * Read a tag string into structure. The one place a tag string is parsed —
+     * including peeling off an optional multisite "site:N:" scope prefix.
+     */
+    public static function parse(string $tag): self
+    {
+        $scope = null;
+        if (preg_match('/^site:(\d+):(.+)$/', $tag, $matches)) {
+            $scope = (int) $matches[1];
+            $tag = $matches[2];
+        }
+
+        $parts = explode(':', $tag);
+        $type = $parts[0];
+
+        // A bare "site:N" tag (the scope tag itself, not a prefix).
+        if ($type === 'site' && $scope === null && count($parts) === 2 && ctype_digit($parts[1])) {
+            return new self('site', (int) $parts[1]);
+        }
+
+        if (in_array($type, self::NUMERIC_TYPES, true) && isset($parts[1]) && ctype_digit($parts[1])) {
+            return new self($type, (int) $parts[1], $parts[2] ?? null, $scope);
+        }
+
+        if (in_array($type, self::NAMED_TYPES, true) && isset($parts[1]) && $parts[1] !== '') {
+            return new self($type, $parts[1], $parts[2] ?? null, $scope);
+        }
+
+        if (in_array($type, self::BARE_TYPES, true) && count($parts) === 1) {
+            return new self($type, null, null, $scope);
+        }
+
+        // Unknown shape — keep the literal so custom tags round-trip exactly.
+        return new self('', null, null, $scope, $tag);
+    }
+
+    /**
+     * @param  array<string|Tag>  $tags
+     * @return self[]
+     */
+    public static function fromMany(array $tags): array
+    {
+        return array_map([self::class, 'from'], $tags);
+    }
+
+    /**
+     * @param  array<string|Tag>  $tags
+     * @return string[]
+     */
+    public static function toStrings(array $tags): array
+    {
+        return array_map(fn ($tag) => (string) $tag, $tags);
+    }
+}

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -222,12 +222,14 @@ final class Tag implements \Stringable
     }
 
     /**
-     * @param  array<string|Tag>  $tags
+     * Normalise a (possibly nested) array of strings/Tags to a flat Tag[].
+     *
+     * @param  array<string|Tag|array>  $tags
      * @return self[]
      */
     public static function fromMany(array $tags): array
     {
-        return array_map([self::class, 'from'], $tags);
+        return array_map([self::class, 'from'], Util::flatten($tags));
     }
 
     /**

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -7,9 +7,9 @@ namespace Genero\Sage\CacheTags;
  *
  * The codebase passes Tags around, not strings; a tag is only turned into a
  * string at a true boundary (the Cache-Tag header, the store, an HTTP purge),
- * and a string only becomes a Tag when one comes in (a site's custom tag, the
- * cachetags/filter-tags filter). parse() and __toString() are the single place
- * that conversion happens.
+ * and a string only becomes a Tag when one comes in (a site's custom string
+ * passed to add()/clear()). parse() and __toString() are the single place that
+ * conversion happens.
  *
  * Context is expressed with two general operations rather than purpose-built
  * methods, so new dimensions (a multisite network, a tenant, …) need no new API:

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -190,8 +190,7 @@ final class Tag implements \Stringable
         // them, so a bare "site:5" stays a tag but "site:5:post:3" is scoped.
         while (count($segments) > 2 && in_array($segments[0], self::SCOPE_DIMENSIONS, true)) {
             $dimension = array_shift($segments);
-            $value = array_shift($segments);
-            $scopes[] = [$dimension, ctype_digit($value) ? (int) $value : $value];
+            $scopes[] = [$dimension, self::intIfCanonical(array_shift($segments))];
         }
 
         $type = $segments[0];
@@ -203,13 +202,23 @@ final class Tag implements \Stringable
         if ($type !== '' && count($segments) <= 3) {
             return new self(
                 $type,
-                $id !== null && ctype_digit($id) ? (int) $id : $id,
+                $id !== null ? self::intIfCanonical($id) : null,
                 $qualifier,
                 $scopes,
             );
         }
 
         return new self('', null, null, $scopes, implode(':', $segments));
+    }
+
+    /**
+     * Cast a segment to int only when it's a canonical integer, so a custom tag's
+     * numeric-looking segment still round-trips verbatim (leading zeros like
+     * "0123", or values past PHP_INT_MAX, are kept as strings).
+     */
+    private static function intIfCanonical(string $value): int|string
+    {
+        return ctype_digit($value) && (string) (int) $value === $value ? (int) $value : $value;
     }
 
     /**

--- a/src/Tags/CoreTags.php
+++ b/src/Tags/CoreTags.php
@@ -45,7 +45,7 @@ class CoreTags
      * Return cache tags for one or multiple posts.
      *
      * @param  int|WP_Post|array<int|WP_Post>|null  $posts
-     * @return string[]
+     * @return Tag[]
      */
     public static function posts($posts = null): array
     {
@@ -61,7 +61,7 @@ class CoreTags
      * Return cache tags for one or multiple terms.
      *
      * @param  int|WP_Term|array<int|WP_Term>|null  $terms
-     * @return string[]
+     * @return Tag[]
      */
     public static function terms($terms = null): array
     {
@@ -77,7 +77,7 @@ class CoreTags
      * Return cache tags for one or multiple term pages.
      *
      * @param  int|WP_Term|array<int|WP_Term>|null  $terms
-     * @return string[]
+     * @return Tag[]
      */
     public static function termPages($terms = null): array
     {
@@ -88,7 +88,7 @@ class CoreTags
      * Return cache tags for one or multiple users.
      *
      * @param  int|WP_User|array<int|WP_User>|null  $users
-     * @return string[]
+     * @return Tag[]
      */
     public static function users($users = null): array
     {
@@ -104,7 +104,7 @@ class CoreTags
      * Return cache tags for one or multiple comments.
      *
      * @param  int|WP_Comment|array<int|WP_Comment>|null  $comments
-     * @return string[]
+     * @return Tag[]
      */
     public static function comments($comments = null): array
     {
@@ -119,7 +119,7 @@ class CoreTags
     /**
      * Return cache tags for the menu in a navigation location.
      *
-     * @return string[]
+     * @return Tag[]
      */
     public static function navigation(?string $location = null): array
     {
@@ -140,7 +140,7 @@ class CoreTags
     /**
      * Return cache tags for a menu.
      *
-     * @return string[]
+     * @return Tag[]
      */
     public static function menu($menu = null): array
     {
@@ -164,7 +164,7 @@ class CoreTags
      * Return cache tags for the current queried object.
      *
      * @param  WP_Post|WP_Term|WP_Post_Type|null  $object
-     * @return string[]
+     * @return Tag[]
      */
     public static function queriedObject($object = null): array
     {
@@ -191,7 +191,7 @@ class CoreTags
     /**
      * Return cache tags for a WP_Query.
      *
-     * @return string[]
+     * @return Tag[]
      */
     public static function query(WP_Query $query): array
     {
@@ -210,7 +210,7 @@ class CoreTags
      *
      * @param  string|object|array<string|object>  $items
      * @param  callable():string[]  $all  resolver for the 'any' keyword
-     * @return string[]
+     * @return Tag[]
      */
     protected static function nameTags($items, string $type, callable $all, ?string $qualifier = null): array
     {
@@ -237,7 +237,7 @@ class CoreTags
      * Return cache tags for one or many post type archives.
      *
      * @param  string|WP_Post_Type|array<string|WP_Post_Type>  $postTypes
-     * @return string[]
+     * @return Tag[]
      */
     public static function archive($postTypes): array
     {
@@ -252,7 +252,7 @@ class CoreTags
      * Return cache tags for one or many taxonomy pages.
      *
      * @param  string|WP_Taxonomy|array<string|WP_Taxonomy>  $taxonomies
-     * @return string[]
+     * @return Tag[]
      */
     public static function taxonomy($taxonomies): array
     {
@@ -267,7 +267,7 @@ class CoreTags
      * Return cache tags for changes to any term in taxonomies.
      *
      * @param  string|WP_Taxonomy|array<string|WP_Taxonomy>  $taxonomies
-     * @return string[]
+     * @return Tag[]
      */
     public static function anyTerm($taxonomies): array
     {
@@ -287,7 +287,7 @@ class CoreTags
      * coarse fallback when a response would otherwise emit too many post tags.
      *
      * @param  string|WP_Post_Type|array<string|WP_Post_Type>  $postTypes
-     * @return string[]
+     * @return Tag[]
      */
     public static function anyArchive($postTypes): array
     {
@@ -303,7 +303,7 @@ class CoreTags
      * Return cache tags for changes to any user in roles.
      *
      * @param  string|WP_Role|array<string|WP_Role>  $roles
-     * @return string[]
+     * @return Tag[]
      */
     public static function anyUser($roles): array
     {
@@ -424,7 +424,7 @@ class CoreTags
      * Return cache tags for one or multiple site options.
      *
      * @param  string|string[]  $options
-     * @return string[]
+     * @return Tag[]
      */
     public static function option($options): array
     {

--- a/src/Tags/CoreTags.php
+++ b/src/Tags/CoreTags.php
@@ -3,6 +3,7 @@
 namespace Genero\Sage\CacheTags\Tags;
 
 use Exception;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Util;
 use WP_Comment;
 use WP_Post;
@@ -16,15 +17,15 @@ use WP_User;
 class CoreTags
 {
     /**
-     * Build "prefix:id" tags for one or many entities given as an id, an object,
-     * or an array of either. Returns [] for null/unrecognised input.
+     * Build tags of $type for one or many entities given as an id, an object, or
+     * an array of either. Returns [] for null/unrecognised input.
      *
      * @param  int|object|array<int|object>|null  $items
      * @param  class-string  $className
      * @param  callable(object):int  $idOf
-     * @return string[]
+     * @return Tag[]
      */
-    protected static function entityTags($items, string $prefix, string $className, callable $idOf): array
+    protected static function entityTags($items, string $type, string $className, callable $idOf): array
     {
         if (is_numeric($items) || $items instanceof $className) {
             $items = [$items];
@@ -35,7 +36,7 @@ class CoreTags
         }
 
         return array_map(
-            fn ($item) => sprintf('%s:%d', $prefix, $item instanceof $className ? $idOf($item) : $item),
+            fn ($item) => Tag::of($type, $item instanceof $className ? $idOf($item) : (int) $item),
             $items
         );
     }
@@ -50,7 +51,7 @@ class CoreTags
     {
         return self::entityTags(
             $posts,
-            prefix: 'post',
+            type: 'post',
             className: WP_Post::class,
             idOf: fn (WP_Post $post) => $post->ID,
         );
@@ -66,7 +67,7 @@ class CoreTags
     {
         return self::entityTags(
             $terms,
-            prefix: 'term',
+            type: 'term',
             className: WP_Term::class,
             idOf: fn (WP_Term $term) => $term->term_id,
         );
@@ -80,7 +81,7 @@ class CoreTags
      */
     public static function termPages($terms = null): array
     {
-        return array_map(fn ($tag) => "$tag:full", self::terms($terms));
+        return array_map(fn (Tag $tag) => $tag->full(), self::terms($terms));
     }
 
     /**
@@ -93,7 +94,7 @@ class CoreTags
     {
         return self::entityTags(
             $users,
-            prefix: 'user',
+            type: 'user',
             className: WP_User::class,
             idOf: fn (WP_User $user) => $user->ID,
         );
@@ -109,7 +110,7 @@ class CoreTags
     {
         return self::entityTags(
             $comments,
-            prefix: 'comment',
+            type: 'comment',
             className: WP_Comment::class,
             idOf: fn (WP_Comment $comment) => $comment->comment_ID,
         );
@@ -156,7 +157,7 @@ class CoreTags
             throw new Exception('CoreTags::menu received an unknown menu: '.(is_scalar($menu) ? $menu : get_debug_type($menu)));
         }
 
-        return ["menu:{$object->term_id}"];
+        return [Tag::menu($object->term_id)];
     }
 
     /**
@@ -211,7 +212,7 @@ class CoreTags
      * @param  callable():string[]  $all  resolver for the 'any' keyword
      * @return string[]
      */
-    protected static function nameTags($items, string $prefix, callable $all, string $suffix = ''): array
+    protected static function nameTags($items, string $type, callable $all, ?string $qualifier = null): array
     {
         if ($items === 'any') {
             $items = $all();
@@ -225,10 +226,11 @@ class CoreTags
             return [];
         }
 
-        return array_map(
-            fn ($item) => sprintf('%s:%s%s', $prefix, is_object($item) ? $item->name : $item, $suffix),
-            $items
-        );
+        return array_map(function ($item) use ($type, $qualifier) {
+            $tag = Tag::of($type, is_object($item) ? $item->name : $item);
+
+            return $qualifier !== null ? $tag->qualify($qualifier) : $tag;
+        }, $items);
     }
 
     /**
@@ -241,7 +243,7 @@ class CoreTags
     {
         return self::nameTags(
             $postTypes,
-            prefix: 'archive',
+            type: 'archive',
             all: [self::class, 'getCacheablePostTypes'],
         );
     }
@@ -256,7 +258,7 @@ class CoreTags
     {
         return self::nameTags(
             $taxonomies,
-            prefix: 'taxonomy',
+            type: 'taxonomy',
             all: [self::class, 'getCacheableTaxonomies'],
         );
     }
@@ -271,9 +273,9 @@ class CoreTags
     {
         return self::nameTags(
             $taxonomies,
-            prefix: 'taxonomy',
+            type: 'taxonomy',
             all: [self::class, 'getCacheableTaxonomies'],
-            suffix: ':any',
+            qualifier: 'any',
         );
     }
 
@@ -291,9 +293,9 @@ class CoreTags
     {
         return self::nameTags(
             $postTypes,
-            prefix: 'archive',
+            type: 'archive',
             all: [self::class, 'getCacheablePostTypes'],
-            suffix: ':any',
+            qualifier: 'any',
         );
     }
 
@@ -307,7 +309,7 @@ class CoreTags
     {
         return self::nameTags(
             $roles,
-            prefix: 'role',
+            type: 'role',
             all: [self::class, 'getCacheableUserRoles'],
         );
     }
@@ -427,7 +429,7 @@ class CoreTags
     public static function option($options): array
     {
         return array_map(
-            fn ($option) => sprintf('option:%s', $option),
+            fn ($option) => Tag::option($option),
             is_array($options) ? $options : [$options]
         );
     }

--- a/src/Tags/GravityformTags.php
+++ b/src/Tags/GravityformTags.php
@@ -2,7 +2,7 @@
 
 namespace Genero\Sage\CacheTags\Tags;
 
-use Genero\Sage\CacheTags\Util;
+use Genero\Sage\CacheTags\Tag;
 
 class GravityformTags
 {
@@ -12,7 +12,7 @@ class GravityformTags
      * @see https://docs.gravityforms.com/form-object/
      *
      * @param  mixed  $forms
-     * @return string[]
+     * @return Tag[]
      */
     public static function forms($forms = null): array
     {
@@ -21,12 +21,10 @@ class GravityformTags
         }
 
         if (is_array($forms)) {
-            $tags = array_map(
-                fn ($form) => [sprintf('gform:%d', isset($form['id']) ? $form['id'] : $form)],
+            return array_map(
+                fn ($form) => Tag::form((int) (isset($form['id']) ? $form['id'] : $form)),
                 $forms
             );
-
-            return Util::flatten($tags);
         }
 
         return [];

--- a/src/Tags/PolylangTags.php
+++ b/src/Tags/PolylangTags.php
@@ -2,6 +2,8 @@
 
 namespace Genero\Sage\CacheTags\Tags;
 
+use Genero\Sage\CacheTags\Tag;
+
 class PolylangTags
 {
     /**
@@ -9,7 +11,7 @@ class PolylangTags
      * fetches posts across all languages (e.g. WP_Query with lang => '').
      *
      * @param  string|string[]  $postTypes
-     * @return string[]
+     * @return Tag[]
      */
     public static function archiveAllLanguages(string|array $postTypes): array
     {
@@ -25,10 +27,10 @@ class PolylangTags
         foreach ($postTypes as $postType) {
             if (pll_is_translated_post_type($postType)) {
                 foreach ($languages as $lang) {
-                    $tags[] = "archive:{$postType}:{$lang}";
+                    $tags[] = Tag::archive($postType)->qualify($lang);
                 }
             } else {
-                $tags[] = "archive:{$postType}";
+                $tags[] = Tag::archive($postType);
             }
         }
 
@@ -38,12 +40,12 @@ class PolylangTags
     /**
      * Return the current language as a cache tag.
      *
-     * @return string[]
+     * @return Tag[]
      */
     public static function language(): array
     {
         $lang = function_exists('pll_current_language') ? pll_current_language() : null;
 
-        return $lang ? ["lang:{$lang}"] : [];
+        return $lang ? [Tag::language($lang)] : [];
     }
 }

--- a/src/Tags/SiteTags.php
+++ b/src/Tags/SiteTags.php
@@ -2,14 +2,15 @@
 
 namespace Genero\Sage\CacheTags\Tags;
 
+use Genero\Sage\CacheTags\Tag;
 use WP_Site;
 
 class SiteTags
 {
     /**
-     * Return cache tag for the current site
+     * Return the cache tag(s) for the current site, given site(s), or 'any'.
      *
-     * @return string[]
+     * @return Tag[]
      */
     public static function sites($sites = null): array
     {
@@ -23,10 +24,7 @@ class SiteTags
 
         if (is_array($sites)) {
             return array_map(
-                fn ($site) => sprintf(
-                    'site:%d',
-                    $site instanceof WP_Site ? $site->blog_id : $site
-                ),
+                fn ($site) => Tag::site((int) ($site instanceof WP_Site ? $site->blog_id : $site)),
                 $sites
             );
         }

--- a/src/Tags/WooCommerceTags.php
+++ b/src/Tags/WooCommerceTags.php
@@ -2,7 +2,7 @@
 
 namespace Genero\Sage\CacheTags\Tags;
 
-use Genero\Sage\CacheTags\Util;
+use Genero\Sage\CacheTags\Tag;
 use WC_Product;
 use WP_Post;
 
@@ -12,7 +12,7 @@ class WooCommerceTags
      * Return cache tags for one or multiple products.
      *
      * @param  mixed  $products
-     * @return string[]
+     * @return Tag[]
      */
     public static function products($products = null): array
     {
@@ -21,27 +21,21 @@ class WooCommerceTags
         }
 
         if (is_array($products)) {
-            $tags = array_map(
-                function ($product) {
-                    $id = match (true) {
-                        $product instanceof WP_Post => $product->ID,
-                        $product instanceof WC_Product => $product->get_id(),
-                        default => $product
-                    };
-
-                    return [sprintf('post:%d', $id)];
-                },
+            return array_map(
+                fn ($product) => Tag::post((int) match (true) {
+                    $product instanceof WP_Post => $product->ID,
+                    $product instanceof WC_Product => $product->get_id(),
+                    default => $product,
+                }),
                 $products
             );
-
-            return Util::flatten($tags);
         }
 
         return [];
     }
 
     /**
-     * @return string[]
+     * @return Tag[]
      */
     public static function shop(): array
     {
@@ -50,6 +44,6 @@ class WooCommerceTags
             return [];
         }
 
-        return ["post:$pageId"];
+        return [Tag::post($pageId)];
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -102,6 +102,11 @@ class Util
     }
 
     /**
+     * Max length of a stored tag or URL — the `varchar(191)` store columns.
+     */
+    const MAX_LENGTH = 191;
+
+    /**
      * Whether a value is a usable cache tag: a non-empty, single header token
      * (no whitespace or control characters) that fits the store column.
      *
@@ -115,14 +120,13 @@ class Util
             return false;
         }
 
-        if (strlen($tag) > (int) apply_filters('cachetags/max-tag-length', 191)) {
+        if (strlen($tag) > self::MAX_LENGTH) {
             return false;
         }
 
-        return (bool) preg_match(
-            apply_filters('cachetags/tag-pattern', '/^[^\s\x00-\x1F]+$/'),
-            $tag
-        );
+        // A single header-safe token: no whitespace (would split the
+        // space-delimited header) or control characters.
+        return (bool) preg_match('/^[^\s\x00-\x1F]+$/', $tag);
     }
 
     /**
@@ -172,7 +176,7 @@ class Util
 
         // The url column is varchar(191); fall back to the path if the query
         // string overflows it, which also bounds pathological junk-param keys.
-        return strlen($full) <= apply_filters('cachetags/max-url-length', 191) ? $full : $url;
+        return strlen($full) <= self::MAX_LENGTH ? $full : $url;
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -66,10 +66,11 @@ class Util
     }
 
     /**
-     * Flatten nested arrays recursively.
+     * Flatten nested arrays recursively, preserving non-array leaves (strings or
+     * Tag objects) as-is.
      *
-     * @param  array<string|array>  $array
-     * @return string[]
+     * @param  array<mixed>  $array
+     * @return list<mixed>
      */
     public static function flatten(array $array): array
     {

--- a/tests/RestTestCase.php
+++ b/tests/RestTestCase.php
@@ -3,6 +3,7 @@
 namespace Genero\Sage\CacheTags\Tests;
 
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tag;
 use ReflectionObject;
 use WP_UnitTestCase;
 
@@ -64,7 +65,8 @@ abstract class RestTestCase extends WP_UnitTestCase
         $prop = (new ReflectionObject($this->cacheTags))->getProperty('purgeTags');
         $prop->setAccessible(true);
 
-        return $prop->getValue($this->cacheTags);
+        // purgeTags holds Tag objects; assertions compare string form.
+        return Tag::toStrings($prop->getValue($this->cacheTags));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,7 @@ tests_add_filter('muplugins_loaded', function (): void {
         ->httpHeader('Cache-Tag')
         ->actions([Core::class, HttpHeader::class, RestApi::class])
         ->autoDetectActions(false)
+        ->baseTag(null) // tested in isolation; keep it out of the shared tag set
         ->bootstrap();
 
     // The activation hook does not run in the test environment, so create the

--- a/tests/integration/test-bootstrap.php
+++ b/tests/integration/test-bootstrap.php
@@ -3,6 +3,7 @@
 use Genero\Sage\CacheTags\Actions\BaseTag;
 use Genero\Sage\CacheTags\Actions\Core;
 use Genero\Sage\CacheTags\Actions\Gravityform;
+use Genero\Sage\CacheTags\Actions\Nonce;
 use Genero\Sage\CacheTags\Actions\Polylang;
 use Genero\Sage\CacheTags\Actions\WooCommerce;
 use Genero\Sage\CacheTags\Bootstrap;
@@ -90,13 +91,13 @@ class TestBootstrap extends WP_UnitTestCase
         $this->assertNotFalse(has_action('shutdown', [$bootstrap, 'purgeCacheTags']));
     }
 
-    public function test_gravityform_action_schedules_the_nonce_cron(): void
+    public function test_nonce_action_schedules_the_cron(): void
     {
         NonceCron::unschedule();
         $cacheTags = (new Bootstrap)->store(TransientStore::class)->actions([])->disable()->bootstrap();
 
         // The action owns the cron — binding it schedules the purge.
-        (new Gravityform($cacheTags))->bind();
+        (new Nonce($cacheTags))->bind();
 
         $this->assertNotFalse(wp_next_scheduled(NonceCron::HOOK));
         NonceCron::unschedule();
@@ -234,10 +235,10 @@ class TestBootstrap extends WP_UnitTestCase
         $this->assertNotContains(Gravityform::class, $result);
     }
 
-    public function test_nonce_cron_is_unscheduled_without_the_gravityform_action(): void
+    public function test_nonce_cron_is_unscheduled_when_the_action_is_removed(): void
     {
-        // Pretend a stale schedule exists, then bootstrap without the Gravityform
-        // action — Bootstrap cleans up the orphaned cron.
+        // Pretend a stale schedule exists, then bootstrap without the Nonce action
+        // (opt-out) — Bootstrap cleans up the orphaned cron.
         NonceCron::register();
         $this->assertNotFalse(wp_next_scheduled(NonceCron::HOOK));
 

--- a/tests/integration/test-bootstrap.php
+++ b/tests/integration/test-bootstrap.php
@@ -197,13 +197,29 @@ class TestBootstrap extends WP_UnitTestCase
 
     public function test_base_tag_action_is_bound_by_default_and_disabled_with_null(): void
     {
-        $withBase = (new Bootstrap)->store(TransientStore::class)->actions([])->disable()->bootstrap();
+        $withBase = (new Bootstrap)->store(TransientStore::class)->actions([])->autoDetectActions(false)->bootstrap();
         $this->assertTrue($withBase->hasAction(BaseTag::class), 'base tag bound by default');
 
         $this->instanceProp()->setValue(null, null);
 
-        $without = (new Bootstrap)->store(TransientStore::class)->actions([])->baseTag(null)->disable()->bootstrap();
+        $without = (new Bootstrap)->store(TransientStore::class)->actions([])->autoDetectActions(false)->baseTag(null)->bootstrap();
         $this->assertFalse($without->hasAction(BaseTag::class), 'baseTag(null) binds nothing');
+    }
+
+    public function test_disabled_bootstrap_binds_nothing_and_leaves_no_nonce_cron(): void
+    {
+        NonceCron::unschedule();
+
+        // Disabled must be fully inert — including not scheduling the Nonce cron,
+        // whose deferred init hook would otherwise survive the synchronous cleanup.
+        $cacheTags = (new Bootstrap)
+            ->store(TransientStore::class)
+            ->actions([Core::class, Nonce::class])
+            ->disable()
+            ->bootstrap();
+
+        $this->assertFalse($cacheTags->hasAction(Nonce::class), 'no actions bound when disabled');
+        $this->assertFalse(wp_next_scheduled(NonceCron::HOOK), 'and no cron scheduled');
     }
 
     public function test_base_tag_action_tags_every_page(): void

--- a/tests/integration/test-bootstrap.php
+++ b/tests/integration/test-bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use Genero\Sage\CacheTags\Actions\BaseTag;
 use Genero\Sage\CacheTags\Actions\Core;
 use Genero\Sage\CacheTags\Actions\Polylang;
 use Genero\Sage\CacheTags\Actions\WooCommerce;
@@ -186,6 +187,30 @@ class TestBootstrap extends WP_UnitTestCase
 
         $this->assertTrue($cacheTags->debug);
         $this->assertSame('Surrogate-Key', $cacheTags->httpHeader);
+    }
+
+    public function test_base_tag_action_is_bound_by_default_and_disabled_with_null(): void
+    {
+        $withBase = (new Bootstrap)->store(TransientStore::class)->actions([])->disable()->bootstrap();
+        $this->assertTrue($withBase->hasAction(BaseTag::class), 'base tag bound by default');
+
+        $this->instanceProp()->setValue(null, null);
+
+        $without = (new Bootstrap)->store(TransientStore::class)->actions([])->baseTag(null)->disable()->bootstrap();
+        $this->assertFalse($without->hasAction(BaseTag::class), 'baseTag(null) binds nothing');
+    }
+
+    public function test_base_tag_action_tags_every_page(): void
+    {
+        $cacheTags = (new Bootstrap)->store(TransientStore::class)->actions([])->disable()->bootstrap();
+
+        $action = new BaseTag($cacheTags, 'page');
+        $action->bind();
+        $this->assertNotFalse(has_action('template_redirect', [$action, 'addBaseTag']));
+        $this->assertNotFalse(has_action('rest_api_init', [$action, 'addBaseTag']));
+
+        $action->addBaseTag();
+        $this->assertContains('page', $cacheTags->get());
     }
 
     // WooCommerce + Polylang are loaded in the test env, so with detection on

--- a/tests/integration/test-bootstrap.php
+++ b/tests/integration/test-bootstrap.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Actions\BaseTag;
 use Genero\Sage\CacheTags\Actions\Core;
+use Genero\Sage\CacheTags\Actions\Gravityform;
 use Genero\Sage\CacheTags\Actions\Polylang;
 use Genero\Sage\CacheTags\Actions\WooCommerce;
 use Genero\Sage\CacheTags\Bootstrap;
@@ -89,9 +90,13 @@ class TestBootstrap extends WP_UnitTestCase
         $this->assertNotFalse(has_action('shutdown', [$bootstrap, 'purgeCacheTags']));
     }
 
-    public function test_schedules_the_nonce_cron_when_enabled(): void
+    public function test_gravityform_action_schedules_the_nonce_cron(): void
     {
-        (new Bootstrap)->store(TransientStore::class)->actions([])->nonceCron(true)->bootstrap();
+        NonceCron::unschedule();
+        $cacheTags = (new Bootstrap)->store(TransientStore::class)->actions([])->disable()->bootstrap();
+
+        // The action owns the cron — binding it schedules the purge.
+        (new Gravityform($cacheTags))->bind();
 
         $this->assertNotFalse(wp_next_scheduled(NonceCron::HOOK));
         NonceCron::unschedule();
@@ -224,6 +229,21 @@ class TestBootstrap extends WP_UnitTestCase
 
         $this->assertContains(WooCommerce::class, $result);
         $this->assertContains(Polylang::class, $result);
+        // Gravity Forms isn't loaded in the test env, so its detection key (also
+        // wired) stays absent — never falsely appended.
+        $this->assertNotContains(Gravityform::class, $result);
+    }
+
+    public function test_nonce_cron_is_unscheduled_without_the_gravityform_action(): void
+    {
+        // Pretend a stale schedule exists, then bootstrap without the Gravityform
+        // action — Bootstrap cleans up the orphaned cron.
+        NonceCron::register();
+        $this->assertNotFalse(wp_next_scheduled(NonceCron::HOOK));
+
+        (new Bootstrap)->store(TransientStore::class)->actions([])->autoDetectActions(false)->bootstrap();
+
+        $this->assertFalse(wp_next_scheduled(NonceCron::HOOK));
     }
 
     public function test_auto_detect_actions_can_be_disabled(): void

--- a/tests/integration/test-cache-tags-core.php
+++ b/tests/integration/test-cache-tags-core.php
@@ -239,25 +239,6 @@ class TestCacheTagsCore extends WP_UnitTestCase
         );
     }
 
-    public function test_purge_queued_fires_the_purged_action_with_the_result(): void
-    {
-        $captured = [];
-        add_action('cachetags/purged', function ($tags, $urls, $result) use (&$captured) {
-            $captured = ['tags' => $tags, 'urls' => $urls, 'result' => $result];
-        }, 10, 3);
-
-        $store = new RecordingStore;
-        $store->urlsFor = ['https://example.com/a/'];
-        $cacheTags = $this->make($store, [new RecordingInvalidator]);
-
-        $cacheTags->clear(['post:1']);
-        $cacheTags->purgeQueued();
-
-        $this->assertSame(['post:1'], $captured['tags'] ?? null);
-        $this->assertSame(['https://example.com/a/'], $captured['urls'] ?? null);
-        $this->assertTrue($captured['result'] ?? null);
-    }
-
     public function test_bind_action_tracks_it_for_has_action(): void
     {
         $cacheTags = $this->make(new RecordingStore, []);

--- a/tests/integration/test-cache-tags.php
+++ b/tests/integration/test-cache-tags.php
@@ -1,6 +1,7 @@
 <?php
 
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tag;
 
 /**
  * The header-byte-budget collapse in CacheTags::get()/bound(): when the combined
@@ -71,6 +72,20 @@ class TestCacheTags extends WP_UnitTestCase
 
         $this->assertContains('post:1', $tags);
         $this->assertNotContains("evil\r\nX-Injected: 1", $tags);
+    }
+
+    // The structured Tag API and raw custom strings interoperate through add().
+    public function test_accepts_tag_objects_alongside_custom_strings(): void
+    {
+        $cacheTags = $this->resetTags();
+        $id = self::factory()->post->create(['post_status' => 'publish']);
+
+        $cacheTags->add([Tag::post($id), 'banner', Tag::archive('post')->any()]);
+
+        $tags = $cacheTags->get();
+        $this->assertContains("post:{$id}", $tags, 'Tag object serialized');
+        $this->assertContains('banner', $tags, 'custom raw string preserved verbatim');
+        $this->assertContains('archive:post:any', $tags);
     }
 
     // The Site action prefixes every tag with "site:N:"; the collapse must see

--- a/tests/integration/test-cache-tags.php
+++ b/tests/integration/test-cache-tags.php
@@ -88,6 +88,20 @@ class TestCacheTags extends WP_UnitTestCase
         $this->assertContains('archive:post:any', $tags);
     }
 
+    public function test_add_accepts_a_single_tag_multiple_args_or_an_array(): void
+    {
+        $cacheTags = $this->resetTags();
+
+        $cacheTags->add(Tag::nonce());                            // single Tag
+        $cacheTags->add('post:1', 'term:2');                      // variadic strings
+        $cacheTags->add(['comment:3', Tag::archive('post')->any()]); // array (back-compat)
+
+        $tags = $cacheTags->get();
+        foreach (['nonce', 'post:1', 'term:2', 'comment:3', 'archive:post:any'] as $expected) {
+            $this->assertContains($expected, $tags);
+        }
+    }
+
     // The Site action prefixes every tag with "site:N:"; the collapse must see
     // through the prefix and re-apply it, or the prefixed post:/term: tags would
     // be dropped instead of collapsed → stale.

--- a/tests/integration/test-fastly-invalidator.php
+++ b/tests/integration/test-fastly-invalidator.php
@@ -42,20 +42,33 @@ class TestFastlyInvalidator extends WP_UnitTestCase
         $this->assertStringNotContainsString('example.com', wp_json_encode($body));
     }
 
-    public function test_clear_chunks_surrogate_keys_to_the_256_limit(): void
+    public function test_clear_chunks_and_dispatches_in_parallel_above_256_keys(): void
     {
+        // >256 keys go through the parallel path; capture the prepared requests.
+        $invalidator = new class extends FastlyCacheInvalidator
+        {
+            /** @var array<int, array<string, mixed>> */
+            public array $dispatched = [];
+
+            protected function dispatchParallel(array $requests): bool
+            {
+                $this->dispatched = $requests;
+
+                return true;
+            }
+        };
+
         $tags = array_map(fn ($i) => "post:{$i}", range(1, 600));
 
-        $ok = (new FastlyCacheInvalidator)->clear([], $tags);
+        $this->assertTrue($invalidator->clear([], $tags));
 
-        $this->assertTrue($ok);
-
-        $batchSizes = array_map(
-            fn ($request) => count(json_decode($request['args']['body'], true)['surrogate_keys']),
-            $this->requests
+        $sizes = array_map(
+            fn ($request) => count(json_decode($request['data'], true)['surrogate_keys']),
+            $invalidator->dispatched
         );
-        // Fastly rejects >256 keys per request, so 600 → 256 + 256 + 88.
-        $this->assertSame([256, 256, 88], $batchSizes);
+        // Fastly rejects >256 keys per request, so 600 → 256 + 256 + 88, each its
+        // own concurrent request.
+        $this->assertSame([256, 256, 88], $sizes);
     }
 
     public function test_clear_returns_false_on_a_non_200_response(): void

--- a/tests/integration/test-fastly-invalidator.php
+++ b/tests/integration/test-fastly-invalidator.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Invalidators\FastlyCacheInvalidator;
 use Genero\Sage\CacheTags\Invalidators\FastlySoftCacheInvalidator;
+use WpOrg\Requests\Response;
 
 /**
  * @covers \Genero\Sage\CacheTags\Invalidators\FastlyCacheInvalidator
@@ -69,6 +70,105 @@ class TestFastlyInvalidator extends WP_UnitTestCase
         // Fastly rejects >256 keys per request, so 600 → 256 + 256 + 88, each its
         // own concurrent request.
         $this->assertSame([256, 256, 88], $sizes);
+    }
+
+    public function test_single_purge_retries_after_a_429_then_succeeds(): void
+    {
+        remove_filter('pre_http_request', [$this, 'capture'], 10);
+        $calls = 0;
+        add_filter('pre_http_request', function () use (&$calls) {
+            $calls++;
+
+            return $calls === 1
+                ? ['response' => ['code' => 429], 'headers' => ['fastly-ratelimit-reset' => (string) (time() + 1)], 'body' => '{}']
+                : ['response' => ['code' => 200], 'body' => '{}'];
+        });
+
+        $invalidator = new class extends FastlyCacheInvalidator
+        {
+            public int $pauses = 0;
+
+            protected function pauseBeforeRetry(int $seconds): void
+            {
+                $this->pauses++; // don't actually sleep in tests
+            }
+        };
+
+        $this->assertTrue($invalidator->clear([], ['post:1']));
+        $this->assertSame(2, $calls, 'retried once after the 429');
+        $this->assertSame(1, $invalidator->pauses);
+    }
+
+    public function test_single_purge_gives_up_after_max_retries(): void
+    {
+        remove_filter('pre_http_request', [$this, 'capture'], 10);
+        $calls = 0;
+        add_filter('pre_http_request', function () use (&$calls) {
+            $calls++;
+
+            return ['response' => ['code' => 429], 'body' => '{"msg":"rate limited"}'];
+        });
+
+        $invalidator = new class extends FastlyCacheInvalidator
+        {
+            protected function pauseBeforeRetry(int $seconds): void {}
+        };
+
+        $this->assertFalse($invalidator->clear([], ['post:1']));
+        $this->assertSame(FastlyCacheInvalidator::MAX_PURGE_RETRIES + 1, $calls, 'initial attempt + retries, then give up');
+    }
+
+    public function test_parallel_path_retries_rate_limited_chunks(): void
+    {
+        $invalidator = new class extends FastlyCacheInvalidator
+        {
+            public int $attempts = 0;
+
+            public int $pauses = 0;
+
+            protected function requestMultiple(array $requests): array
+            {
+                $this->attempts++;
+                // Rate-limit the whole window once, then succeed.
+                $code = $this->attempts === 1 ? 429 : 200;
+
+                return array_map(function () use ($code) {
+                    $response = new Response;
+                    $response->status_code = $code;
+
+                    return $response;
+                }, $requests);
+            }
+
+            protected function pauseBeforeRetry(int $seconds): void
+            {
+                $this->pauses++;
+            }
+        };
+
+        // >256 keys → the parallel path.
+        $tags = array_map(fn ($i) => "post:{$i}", range(1, 300));
+
+        $this->assertTrue($invalidator->clear([], $tags));
+        $this->assertSame(2, $invalidator->attempts, 'dispatched again after the 429');
+        $this->assertSame(1, $invalidator->pauses);
+    }
+
+    public function test_backoff_honours_the_reset_header_capped_and_floored(): void
+    {
+        $invalidator = new class extends FastlyCacheInvalidator
+        {
+            public function backoff(string $reset): int
+            {
+                return $this->backoffSeconds($reset);
+            }
+        };
+
+        $this->assertGreaterThanOrEqual(4, $invalidator->backoff((string) (time() + 5)));
+        $this->assertLessThanOrEqual(5, $invalidator->backoff((string) (time() + 5)));
+        $this->assertSame(FastlyCacheInvalidator::MAX_BACKOFF_SECONDS, $invalidator->backoff((string) (time() + 9999)), 'capped');
+        $this->assertSame(1, $invalidator->backoff(''), 'floored when no reset header');
+        $this->assertSame(1, $invalidator->backoff((string) (time() - 100)), 'floored when reset is past');
     }
 
     public function test_clear_returns_false_on_a_non_200_response(): void

--- a/tests/integration/test-fastly-invalidator.php
+++ b/tests/integration/test-fastly-invalidator.php
@@ -154,21 +154,30 @@ class TestFastlyInvalidator extends WP_UnitTestCase
         $this->assertSame(1, $invalidator->pauses);
     }
 
-    public function test_backoff_honours_the_reset_header_capped_and_floored(): void
+    public function test_backoff_precedence_retry_after_then_reset_then_exponential(): void
     {
         $invalidator = new class extends FastlyCacheInvalidator
         {
-            public function backoff(string $reset): int
+            public function backoff(string $retryAfter, string $reset, int $attempt): int
             {
-                return $this->backoffSeconds($reset);
+                return $this->backoffSeconds($retryAfter, $reset, $attempt);
             }
         };
 
-        $this->assertGreaterThanOrEqual(4, $invalidator->backoff((string) (time() + 5)));
-        $this->assertLessThanOrEqual(5, $invalidator->backoff((string) (time() + 5)));
-        $this->assertSame(FastlyCacheInvalidator::MAX_BACKOFF_SECONDS, $invalidator->backoff((string) (time() + 9999)), 'capped');
-        $this->assertSame(1, $invalidator->backoff(''), 'floored when no reset header');
-        $this->assertSame(1, $invalidator->backoff((string) (time() - 100)), 'floored when reset is past');
+        // 1. Retry-After (delta seconds) wins, even over a far-future reset.
+        $this->assertSame(3, $invalidator->backoff('3', (string) (time() + 9999), 0));
+
+        // 2. Fastly-RateLimit-Reset (Unix ts) when there's no Retry-After.
+        $this->assertGreaterThanOrEqual(4, $invalidator->backoff('', (string) (time() + 5), 0));
+        $this->assertLessThanOrEqual(5, $invalidator->backoff('', (string) (time() + 5), 0));
+        $this->assertSame(FastlyCacheInvalidator::MAX_BACKOFF_SECONDS, $invalidator->backoff('', (string) (time() + 9999), 0), 'capped');
+        $this->assertSame(1, $invalidator->backoff('', (string) (time() - 100), 0), 'floored when reset is past');
+
+        // 3. No timing header (the realistic purge-429 case): exponential backoff.
+        $this->assertSame(1, $invalidator->backoff('', '', 0));
+        $this->assertSame(2, $invalidator->backoff('', '', 1));
+        $this->assertSame(8, $invalidator->backoff('', '', 3));
+        $this->assertSame(FastlyCacheInvalidator::MAX_BACKOFF_SECONDS, $invalidator->backoff('', '', 10), 'capped');
     }
 
     public function test_clear_returns_false_on_a_non_200_response(): void

--- a/tests/integration/test-gravityform.php
+++ b/tests/integration/test-gravityform.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Actions\Gravityform;
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tag;
 
 /**
  * @covers \Genero\Sage\CacheTags\Actions\Gravityform
@@ -78,11 +79,11 @@ class TestGravityform extends WP_UnitTestCase
 
         $purge->setValue($cacheTags, []);
         $action->onSaveForm(['id' => 7], false);
-        $this->assertContains('gform:7', $purge->getValue($cacheTags));
+        $this->assertContains('gform:7', Tag::toStrings($purge->getValue($cacheTags)));
 
         $purge->setValue($cacheTags, []);
         $action->onSaveForm(['id' => 7], true);
-        $this->assertNotContains('gform:7', $purge->getValue($cacheTags), 'a new form has nothing cached yet');
+        $this->assertNotContains('gform:7', Tag::toStrings($purge->getValue($cacheTags)), 'a new form has nothing cached yet');
     }
 
     public function test_prepopulated_form_request_is_non_cacheable(): void

--- a/tests/integration/test-kinsta-invalidators.php
+++ b/tests/integration/test-kinsta-invalidators.php
@@ -109,14 +109,27 @@ class TestKinstaInvalidators extends WP_UnitTestCase
         $this->assertTrue((new KinstaCacheInvalidator)->flush());
     }
 
-    public function test_clear_runs_the_real_curl_request_and_reports_failure_when_unreachable(): void
+    public function test_clear_runs_the_real_curl_request_and_logs_failure_when_unreachable(): void
     {
         // The Kinsta MU endpoint (https://localhost/kinsta-clear-cache/...) isn't
         // reachable from the test runner, so the real cURL in post() executes and
         // returns a connection failure — exercising the actual request code path
-        // rather than a subclass override.
-        $result = (new KinstaCacheInvalidator)->clear(['https://example.com/a/'], ['post:1']);
+        // rather than a subclass override, and surfacing it for diagnosis.
+        $invalidator = new class extends KinstaCacheInvalidator
+        {
+            /** @var array<int, array<string, mixed>> */
+            public array $failures = [];
+
+            protected function logPurgeFailure(string $endpoint, int $status, int $errno, string $error): void
+            {
+                $this->failures[] = ['endpoint' => $endpoint, 'status' => $status, 'errno' => $errno];
+            }
+        };
+
+        $result = $invalidator->clear(['https://example.com/a/'], ['post:1']);
 
         $this->assertFalse($result);
+        $this->assertNotEmpty($invalidator->failures, 'a failed purge is logged so it can be noticed');
+        $this->assertNotSame(0, $invalidator->failures[0]['errno'], 'the connection error is captured');
     }
 }

--- a/tests/integration/test-kinsta-invalidators.php
+++ b/tests/integration/test-kinsta-invalidators.php
@@ -63,17 +63,18 @@ class TestKinstaInvalidators extends WP_UnitTestCase
         $this->assertStringContainsString('example.com', urldecode($invalidator->posts[0][1]));
     }
 
-    public function test_clear_bulk_flushes_when_it_would_take_more_than_three_requests(): void
+    public function test_clear_bulk_routes_to_the_throttled_endpoint_not_a_full_flush(): void
     {
         $invalidator = new class extends KinstaCacheInvalidator
         {
             public bool $flushed = false;
 
-            public int $postCount = 0;
+            /** @var string[] */
+            public array $endpoints = [];
 
             protected function post(string $endpoint, string $body): bool
             {
-                $this->postCount++;
+                $this->endpoints[] = $endpoint;
 
                 return true;
             }
@@ -92,8 +93,13 @@ class TestKinstaInvalidators extends WP_UnitTestCase
         }
 
         $this->assertTrue($invalidator->clear($urls, ['post:1']));
-        $this->assertTrue($invalidator->flushed, 'over three chunks → single bulk flush');
-        $this->assertSame(0, $invalidator->postCount, 'individual posts skipped');
+        $this->assertFalse($invalidator->flushed, 'a bulk purge must NOT nuke the whole cache');
+        $this->assertGreaterThan(KinstaCacheInvalidator::IMMEDIATE_MAX_REQUESTS, count($invalidator->endpoints));
+        $this->assertSame(
+            [KinstaCacheInvalidator::THROTTLED_PATH],
+            array_values(array_unique($invalidator->endpoints)),
+            'bulk chunks all go to the throttled endpoint',
+        );
     }
 
     public function test_flush_calls_the_clear_all_endpoint(): void

--- a/tests/integration/test-nonce-cron.php
+++ b/tests/integration/test-nonce-cron.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\NonceCron;
+use Genero\Sage\CacheTags\Tag;
 
 /**
  * @covers \Genero\Sage\CacheTags\NonceCron
@@ -35,7 +36,7 @@ class TestNonceCron extends WP_UnitTestCase
 
         NonceCron::purge();
 
-        $this->assertContains('nonce', $prop->getValue($cacheTags));
+        $this->assertContains('nonce', Tag::toStrings($prop->getValue($cacheTags)));
     }
 
     public function test_unschedule_clears_the_event(): void

--- a/tests/integration/test-polylang.php
+++ b/tests/integration/test-polylang.php
@@ -60,7 +60,7 @@ class TestPolylang extends WP_UnitTestCase
     public function test_suffixes_translated_archive_tags_with_the_language(): void
     {
         // 'post' is a translated post type by default.
-        $tags = $this->action()->filterArchiveTags(['archive:post', 'post:5']);
+        $tags = Tag::toStrings($this->action()->filterArchiveTags(['archive:post', 'post:5']));
 
         $this->assertSame(['archive:post:en', 'post:5'], $tags);
     }
@@ -75,7 +75,7 @@ class TestPolylang extends WP_UnitTestCase
         // No current language (admin/cron/WC/REST purge context).
         PLL()->curlang = null;
 
-        $tags = $this->action()->filterArchiveTags(['archive:post', 'post:5']);
+        $tags = Tag::toStrings($this->action()->filterArchiveTags(['archive:post', 'post:5']));
 
         // A bare archive tag must reach every language's stored listing.
         $this->assertContains('archive:post:en', $tags);

--- a/tests/integration/test-polylang.php
+++ b/tests/integration/test-polylang.php
@@ -86,7 +86,7 @@ class TestPolylang extends WP_UnitTestCase
 
     public function test_tags_helper_returns_the_current_language(): void
     {
-        $this->assertSame(['lang:en'], PolylangTags::language());
+        $this->assertSame(['lang:en'], Tag::toStrings(PolylangTags::language()));
     }
 
     public function test_tags_helper_builds_a_per_language_archive(): void
@@ -97,7 +97,7 @@ class TestPolylang extends WP_UnitTestCase
             $model->clean_languages_cache();
         }
 
-        $tags = PolylangTags::archiveAllLanguages('post');
+        $tags = Tag::toStrings(PolylangTags::archiveAllLanguages('post'));
 
         // 'post' is translated, so it expands to one archive tag per language.
         $this->assertContains('archive:post:en', $tags);

--- a/tests/integration/test-polylang.php
+++ b/tests/integration/test-polylang.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Actions\Polylang;
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\PolylangTags;
 
 /**
@@ -139,7 +140,7 @@ class TestPolylang extends WP_UnitTestCase
 
         $this->action()->onPostStatusTransition('publish', 'draft', get_post($postId));
 
-        $this->assertContains('archive:post:en', $purge->getValue($cacheTags));
+        $this->assertContains('archive:post:en', Tag::toStrings($purge->getValue($cacheTags)));
     }
 
     // H2: a permanent delete never passes through transition_post_status, so the
@@ -156,7 +157,7 @@ class TestPolylang extends WP_UnitTestCase
 
         $this->action()->onPostDelete($postId);
 
-        $this->assertContains('archive:post:en', $purge->getValue($cacheTags));
+        $this->assertContains('archive:post:en', Tag::toStrings($purge->getValue($cacheTags)));
     }
 
     // H2: the lang: tag must be registered before the priority-10 save/header

--- a/tests/integration/test-site-action.php
+++ b/tests/integration/test-site-action.php
@@ -27,7 +27,7 @@ class TestSiteAction extends WP_UnitTestCase
     public function test_does_not_double_prefix_a_site_tag(): void
     {
         $id = get_current_blog_id();
-        $siteTag = SiteTags::sites()[0];
+        $siteTag = (string) SiteTags::sites()[0];
 
         $result = $this->action()->addSitePrefix([$siteTag, 'post:1']);
 

--- a/tests/integration/test-site-action.php
+++ b/tests/integration/test-site-action.php
@@ -34,6 +34,17 @@ class TestSiteAction extends WP_UnitTestCase
         $this->assertSame([$siteTag, "site:{$id}:post:1"], $result);
     }
 
+    // Only THIS site's own bare tag is left unscoped; a custom site:* tag or
+    // another site's tag flowing through still gets scoped (no cross-site collision).
+    public function test_scopes_a_custom_or_foreign_site_tag(): void
+    {
+        $id = get_current_blog_id();
+
+        $result = $this->action()->addSitePrefix(['site:foo', "site:{$id}", 'post:1']);
+
+        $this->assertSame(["site:{$id}:site:foo", "site:{$id}", "site:{$id}:post:1"], $result);
+    }
+
     public function test_add_site_tag_adds_the_current_site(): void
     {
         $cacheTags = CacheTags::getInstance();

--- a/tests/integration/test-site-action.php
+++ b/tests/integration/test-site-action.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Actions\Site;
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\SiteTags;
 
 /**
@@ -19,7 +20,7 @@ class TestSiteAction extends WP_UnitTestCase
     {
         $id = get_current_blog_id();
 
-        $result = $this->action()->addSitePrefix(['post:1', 'term:5']);
+        $result = Tag::toStrings($this->action()->addSitePrefix(['post:1', 'term:5']));
 
         $this->assertSame(["site:{$id}:post:1", "site:{$id}:term:5"], $result);
     }
@@ -29,7 +30,7 @@ class TestSiteAction extends WP_UnitTestCase
         $id = get_current_blog_id();
         $siteTag = (string) SiteTags::sites()[0];
 
-        $result = $this->action()->addSitePrefix([$siteTag, 'post:1']);
+        $result = Tag::toStrings($this->action()->addSitePrefix([$siteTag, 'post:1']));
 
         $this->assertSame([$siteTag, "site:{$id}:post:1"], $result);
     }
@@ -40,7 +41,7 @@ class TestSiteAction extends WP_UnitTestCase
     {
         $id = get_current_blog_id();
 
-        $result = $this->action()->addSitePrefix(['site:foo', "site:{$id}", 'post:1']);
+        $result = Tag::toStrings($this->action()->addSitePrefix(['site:foo', "site:{$id}", 'post:1']));
 
         $this->assertSame(["site:{$id}:site:foo", "site:{$id}", "site:{$id}:post:1"], $result);
     }

--- a/tests/integration/test-tags.php
+++ b/tests/integration/test-tags.php
@@ -1,12 +1,13 @@
 <?php
 
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\GravityformTags;
 use Genero\Sage\CacheTags\Tags\SiteTags;
 use Genero\Sage\CacheTags\Tags\WooCommerceTags;
 
 /**
- * The tag "vocabulary" classes — the strings these build are what gets purged,
- * so the per-shape branches matter.
+ * The tag "vocabulary" classes — the builders return Tag objects, asserted here
+ * in their string form.
  *
  * @covers \Genero\Sage\CacheTags\Tags\GravityformTags
  * @covers \Genero\Sage\CacheTags\Tags\SiteTags
@@ -14,34 +15,43 @@ use Genero\Sage\CacheTags\Tags\WooCommerceTags;
  */
 class TestTags extends WP_UnitTestCase
 {
+    /**
+     * @param  Tag[]  $tags
+     * @return string[]
+     */
+    private function strings(array $tags): array
+    {
+        return Tag::toStrings($tags);
+    }
+
     public function test_gravityform_forms_from_id_object_array_and_null(): void
     {
-        $this->assertSame(['gform:5'], GravityformTags::forms(5));
-        $this->assertSame(['gform:5'], GravityformTags::forms(['id' => 5]));
-        $this->assertSame(['gform:1', 'gform:2'], GravityformTags::forms([1, 2]));
-        $this->assertSame([], GravityformTags::forms(null));
+        $this->assertSame(['gform:5'], $this->strings(GravityformTags::forms(5)));
+        $this->assertSame(['gform:5'], $this->strings(GravityformTags::forms(['id' => 5])));
+        $this->assertSame(['gform:1', 'gform:2'], $this->strings(GravityformTags::forms([1, 2])));
+        $this->assertSame([], $this->strings(GravityformTags::forms(null)));
     }
 
     public function test_site_tags_for_current_explicit_and_unhandled_input(): void
     {
         $current = get_current_blog_id();
 
-        $this->assertSame(["site:{$current}"], SiteTags::sites(), 'null → current site');
-        $this->assertSame(['site:7'], SiteTags::sites(7));
-        $this->assertSame(['site:3', 'site:4'], SiteTags::sites([3, 4]));
+        $this->assertSame(["site:{$current}"], $this->strings(SiteTags::sites()), 'null → current site');
+        $this->assertSame(['site:7'], $this->strings(SiteTags::sites(7)));
+        $this->assertSame(['site:3', 'site:4'], $this->strings(SiteTags::sites([3, 4])));
         // 'any' on a single-site install is just the current site.
-        $this->assertSame(["site:{$current}"], SiteTags::sites('any'));
-        $this->assertSame([], SiteTags::sites(new stdClass));
+        $this->assertSame(["site:{$current}"], $this->strings(SiteTags::sites('any')));
+        $this->assertSame([], $this->strings(SiteTags::sites(new stdClass)));
     }
 
     public function test_woocommerce_products_from_id_array_post_and_null(): void
     {
-        $this->assertSame(['post:10'], WooCommerceTags::products(10));
-        $this->assertSame(['post:10', 'post:11'], WooCommerceTags::products([10, 11]));
-        $this->assertSame([], WooCommerceTags::products(null));
+        $this->assertSame(['post:10'], $this->strings(WooCommerceTags::products(10)));
+        $this->assertSame(['post:10', 'post:11'], $this->strings(WooCommerceTags::products([10, 11])));
+        $this->assertSame([], $this->strings(WooCommerceTags::products(null)));
 
         $post = self::factory()->post->create_and_get();
-        $this->assertSame(["post:{$post->ID}"], WooCommerceTags::products($post));
+        $this->assertSame(["post:{$post->ID}"], $this->strings(WooCommerceTags::products($post)));
     }
 
     public function test_woocommerce_shop_tag_with_and_without_a_shop_page(): void
@@ -52,9 +62,9 @@ class TestTags extends WP_UnitTestCase
 
         $shopId = self::factory()->post->create();
         update_option('woocommerce_shop_page_id', $shopId);
-        $this->assertSame(["post:{$shopId}"], WooCommerceTags::shop());
+        $this->assertSame(["post:{$shopId}"], $this->strings(WooCommerceTags::shop()));
 
         delete_option('woocommerce_shop_page_id');
-        $this->assertSame([], WooCommerceTags::shop(), 'no shop page → no tag');
+        $this->assertSame([], $this->strings(WooCommerceTags::shop()), 'no shop page → no tag');
     }
 }

--- a/tests/integration/test-woocommerce-integration.php
+++ b/tests/integration/test-woocommerce-integration.php
@@ -2,6 +2,7 @@
 
 use Genero\Sage\CacheTags\Actions\WooCommerce;
 use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Tag;
 
 /**
  * Real integration against an installed WooCommerce: exercises the action's
@@ -159,7 +160,7 @@ class TestWooCommerceIntegration extends WP_UnitTestCase
         $ref = new ReflectionProperty($cacheTags, 'purgeTags');
         $ref->setAccessible(true);
 
-        return $ref->getValue($cacheTags);
+        return Tag::toStrings($ref->getValue($cacheTags));
     }
 
     private function resetPurge(): void

--- a/tests/unit/test-core-tags.php
+++ b/tests/unit/test-core-tags.php
@@ -1,58 +1,69 @@
 <?php
 
+use Genero\Sage\CacheTags\Tag;
 use Genero\Sage\CacheTags\Tags\CoreTags;
 
 /**
- * Pure formatting behaviour of the tag helpers.
+ * Pure formatting behaviour of the tag helpers — the builders return Tag objects,
+ * asserted here in their string form.
  *
  * @covers \Genero\Sage\CacheTags\Tags\CoreTags
  */
 class TestCoreTags extends WP_UnitTestCase
 {
+    /**
+     * @param  Tag[]  $tags
+     * @return string[]
+     */
+    private function strings(array $tags): array
+    {
+        return Tag::toStrings($tags);
+    }
+
     public function test_posts_formats_ids_and_objects(): void
     {
         $post = self::factory()->post->create_and_get();
 
-        $this->assertSame(['post:1'], CoreTags::posts(1));
-        $this->assertSame(['post:1', 'post:2'], CoreTags::posts([1, 2]));
-        $this->assertSame(["post:{$post->ID}"], CoreTags::posts($post));
-        $this->assertSame([], CoreTags::posts(null));
+        $this->assertSame(['post:1'], $this->strings(CoreTags::posts(1)));
+        $this->assertSame(['post:1', 'post:2'], $this->strings(CoreTags::posts([1, 2])));
+        $this->assertSame(["post:{$post->ID}"], $this->strings(CoreTags::posts($post)));
+        $this->assertSame([], $this->strings(CoreTags::posts(null)));
     }
 
     public function test_terms_and_term_pages(): void
     {
-        $this->assertSame(['term:5'], CoreTags::terms(5));
-        $this->assertSame(['term:5', 'term:6'], CoreTags::terms([5, 6]));
-        $this->assertSame(['term:5:full'], CoreTags::termPages(5));
+        $this->assertSame(['term:5'], $this->strings(CoreTags::terms(5)));
+        $this->assertSame(['term:5', 'term:6'], $this->strings(CoreTags::terms([5, 6])));
+        $this->assertSame(['term:5:full'], $this->strings(CoreTags::termPages(5)));
     }
 
     public function test_users(): void
     {
-        $this->assertSame(['user:2'], CoreTags::users(2));
-        $this->assertSame(['user:2', 'user:3'], CoreTags::users([2, 3]));
+        $this->assertSame(['user:2'], $this->strings(CoreTags::users(2)));
+        $this->assertSame(['user:2', 'user:3'], $this->strings(CoreTags::users([2, 3])));
     }
 
     public function test_comments(): void
     {
-        $this->assertSame(['comment:9'], CoreTags::comments(9));
+        $this->assertSame(['comment:9'], $this->strings(CoreTags::comments(9)));
     }
 
     public function test_archive_accepts_string_and_array(): void
     {
-        $this->assertSame(['archive:post'], CoreTags::archive('post'));
-        $this->assertSame(['archive:post', 'archive:page'], CoreTags::archive(['post', 'page']));
+        $this->assertSame(['archive:post'], $this->strings(CoreTags::archive('post')));
+        $this->assertSame(['archive:post', 'archive:page'], $this->strings(CoreTags::archive(['post', 'page'])));
     }
 
     public function test_taxonomy_and_any_term(): void
     {
-        $this->assertSame(['taxonomy:category'], CoreTags::taxonomy('category'));
-        $this->assertSame(['taxonomy:category:any'], CoreTags::anyTerm('category'));
+        $this->assertSame(['taxonomy:category'], $this->strings(CoreTags::taxonomy('category')));
+        $this->assertSame(['taxonomy:category:any'], $this->strings(CoreTags::anyTerm('category')));
     }
 
     public function test_any_archive(): void
     {
-        $this->assertSame(['archive:post:any'], CoreTags::anyArchive('post'));
-        $this->assertSame(['archive:post:any', 'archive:page:any'], CoreTags::anyArchive(['post', 'page']));
+        $this->assertSame(['archive:post:any'], $this->strings(CoreTags::anyArchive('post')));
+        $this->assertSame(['archive:post:any', 'archive:page:any'], $this->strings(CoreTags::anyArchive(['post', 'page'])));
     }
 
     public function test_cacheable_user_roles_are_slugs(): void
@@ -67,12 +78,12 @@ class TestCoreTags extends WP_UnitTestCase
         $post = self::factory()->post->create_and_get();
         $termId = self::factory()->category->create();
 
-        $this->assertSame(["post:{$post->ID}"], CoreTags::queriedObject($post));
+        $this->assertSame(["post:{$post->ID}"], $this->strings(CoreTags::queriedObject($post)));
         $this->assertSame(
             ["term:{$termId}", "term:{$termId}:full"],
-            CoreTags::queriedObject(get_term($termId))
+            $this->strings(CoreTags::queriedObject(get_term($termId)))
         );
-        $this->assertSame(['archive:post'], CoreTags::queriedObject(get_post_type_object('post')));
+        $this->assertSame(['archive:post'], $this->strings(CoreTags::queriedObject(get_post_type_object('post'))));
     }
 
     public function test_query_tags_each_post_in_a_wp_query(): void
@@ -82,27 +93,27 @@ class TestCoreTags extends WP_UnitTestCase
 
         $this->assertSame(
             array_map(fn ($id) => "post:{$id}", $ids),
-            CoreTags::query($query)
+            $this->strings(CoreTags::query($query))
         );
     }
 
     public function test_any_user(): void
     {
-        $this->assertSame(['role:editor'], CoreTags::anyUser('editor'));
-        $this->assertSame(['role:editor', 'role:author'], CoreTags::anyUser(['editor', 'author']));
+        $this->assertSame(['role:editor'], $this->strings(CoreTags::anyUser('editor')));
+        $this->assertSame(['role:editor', 'role:author'], $this->strings(CoreTags::anyUser(['editor', 'author'])));
     }
 
     public function test_menu_and_navigation(): void
     {
         $menuId = wp_create_nav_menu('Footer');
 
-        $this->assertSame(["menu:{$menuId}"], CoreTags::menu($menuId));
+        $this->assertSame(["menu:{$menuId}"], $this->strings(CoreTags::menu($menuId)));
 
         register_nav_menu('footer', 'Footer location');
         set_theme_mod('nav_menu_locations', ['footer' => $menuId]);
 
-        $this->assertSame(["menu:{$menuId}"], CoreTags::navigation('footer'));
-        $this->assertSame([], CoreTags::navigation('missing-location'));
+        $this->assertSame(["menu:{$menuId}"], $this->strings(CoreTags::navigation('footer')));
+        $this->assertSame([], $this->strings(CoreTags::navigation('missing-location')));
     }
 
     public function test_is_cacheable_predicates(): void
@@ -123,8 +134,8 @@ class TestCoreTags extends WP_UnitTestCase
 
     public function test_option_formats_option_tags(): void
     {
-        $this->assertSame(['option:blogname'], CoreTags::option('blogname'));
-        $this->assertSame(['option:blogname', 'option:foo'], CoreTags::option(['blogname', 'foo']));
+        $this->assertSame(['option:blogname'], $this->strings(CoreTags::option('blogname')));
+        $this->assertSame(['option:blogname', 'option:foo'], $this->strings(CoreTags::option(['blogname', 'foo'])));
     }
 
     public function test_cacheable_options_default_and_filter(): void
@@ -138,20 +149,20 @@ class TestCoreTags extends WP_UnitTestCase
 
     public function test_any_keyword_expands_to_the_cacheable_sets(): void
     {
-        $this->assertContains('archive:post', CoreTags::archive('any'));
-        $this->assertContains('taxonomy:category', CoreTags::taxonomy('any'));
-        $this->assertContains('taxonomy:category:any', CoreTags::anyTerm('any'));
-        $this->assertContains('archive:post:any', CoreTags::anyArchive('any'));
-        $this->assertContains('role:administrator', CoreTags::anyUser('any'));
+        $this->assertContains('archive:post', $this->strings(CoreTags::archive('any')));
+        $this->assertContains('taxonomy:category', $this->strings(CoreTags::taxonomy('any')));
+        $this->assertContains('taxonomy:category:any', $this->strings(CoreTags::anyTerm('any')));
+        $this->assertContains('archive:post:any', $this->strings(CoreTags::anyArchive('any')));
+        $this->assertContains('role:administrator', $this->strings(CoreTags::anyUser('any')));
     }
 
     public function test_set_builders_accept_wp_objects(): void
     {
-        $this->assertSame(['archive:post'], CoreTags::archive(get_post_type_object('post')));
-        $this->assertSame(['archive:post:any'], CoreTags::anyArchive(get_post_type_object('post')));
-        $this->assertSame(['taxonomy:category'], CoreTags::taxonomy(get_taxonomy('category')));
-        $this->assertSame(['taxonomy:category:any'], CoreTags::anyTerm(get_taxonomy('category')));
-        $this->assertSame(['role:administrator'], CoreTags::anyUser(get_role('administrator')));
+        $this->assertSame(['archive:post'], $this->strings(CoreTags::archive(get_post_type_object('post'))));
+        $this->assertSame(['archive:post:any'], $this->strings(CoreTags::anyArchive(get_post_type_object('post'))));
+        $this->assertSame(['taxonomy:category'], $this->strings(CoreTags::taxonomy(get_taxonomy('category'))));
+        $this->assertSame(['taxonomy:category:any'], $this->strings(CoreTags::anyTerm(get_taxonomy('category'))));
+        $this->assertSame(['role:administrator'], $this->strings(CoreTags::anyUser(get_role('administrator'))));
     }
 
     public function test_builders_return_empty_for_unusable_input(): void
@@ -172,9 +183,9 @@ class TestCoreTags extends WP_UnitTestCase
         $menuId = wp_create_nav_menu('Primary');
 
         // wp_nav_menu()'s `menu` arg can be an id, slug, name, or object.
-        $this->assertSame(["menu:{$menuId}"], CoreTags::menu($menuId));
-        $this->assertSame(["menu:{$menuId}"], CoreTags::menu('primary'));
-        $this->assertSame(["menu:{$menuId}"], CoreTags::menu('Primary'));
+        $this->assertSame(["menu:{$menuId}"], $this->strings(CoreTags::menu($menuId)));
+        $this->assertSame(["menu:{$menuId}"], $this->strings(CoreTags::menu('primary')));
+        $this->assertSame(["menu:{$menuId}"], $this->strings(CoreTags::menu('Primary')));
     }
 
     public function test_menu_throws_for_an_unknown_menu(): void

--- a/tests/unit/test-tag.php
+++ b/tests/unit/test-tag.php
@@ -37,6 +37,9 @@ class TestTag extends WP_UnitTestCase
         yield 'custom single' => ['banner'];
         yield 'custom deep' => ['a:b:c:d:e'];
         yield 'scoped custom' => ['site:3:my:custom:tag'];
+        // Numeric-looking custom segments must survive verbatim, not be coerced.
+        yield 'zero-padded id' => ['sku:0123'];
+        yield 'overflow id' => ['ext:99999999999999999999'];
     }
 
     /**
@@ -104,6 +107,17 @@ class TestTag extends WP_UnitTestCase
         $this->assertSame('site', $tag->type);
         $this->assertSame(5, $tag->id);
         $this->assertSame([], $tag->scopes);
+    }
+
+    public function test_only_canonical_integers_are_coerced_to_int(): void
+    {
+        // A real post id is a canonical int.
+        $this->assertSame(5, Tag::parse('post:5')->id);
+
+        // A custom tag's non-canonical numeric segment stays a string so it
+        // round-trips verbatim (no leading-zero stripping or overflow).
+        $this->assertSame('0123', Tag::parse('sku:0123')->id);
+        $this->assertSame('99999999999999999999', Tag::parse('ext:99999999999999999999')->id);
     }
 
     public function test_from_accepts_strings_and_tags(): void

--- a/tests/unit/test-tag.php
+++ b/tests/unit/test-tag.php
@@ -35,6 +35,7 @@ class TestTag extends WP_UnitTestCase
         // A site's own custom tags must survive verbatim.
         yield 'custom' => ['my:custom:tag'];
         yield 'custom single' => ['banner'];
+        yield 'custom deep' => ['a:b:c:d:e'];
         yield 'scoped custom' => ['site:3:my:custom:tag'];
     }
 
@@ -52,47 +53,57 @@ class TestTag extends WP_UnitTestCase
         $this->assertSame('term:9:full', (string) Tag::term(9)->full());
         $this->assertSame('archive:post', (string) Tag::archive('post'));
         $this->assertSame('archive:post:any', (string) Tag::archive('post')->any());
-        $this->assertSame('archive:post:fi', (string) Tag::archive('post')->inLanguage('fi'));
         $this->assertSame('taxonomy:category:any', (string) Tag::taxonomy('category')->any());
         $this->assertSame('role:editor', (string) Tag::role('editor'));
         $this->assertSame('option:blogname', (string) Tag::option('blogname'));
         $this->assertSame('lang:fi', (string) Tag::language('fi'));
         $this->assertSame('nonce', (string) Tag::nonce());
         $this->assertSame('site:1', (string) Tag::site(1));
+        $this->assertSame('gform:5', (string) Tag::form(5));
+        $this->assertSame('custom:9', (string) Tag::of('custom', 9));
     }
 
-    public function test_parse_extracts_structured_fields(): void
+    public function test_qualify_is_the_general_trailing_variant(): void
+    {
+        // Replaces the i18n-specific inLanguage() — language is just a qualifier.
+        $this->assertSame('archive:post:fi', (string) Tag::archive('post')->qualify('fi'));
+        $this->assertSame('archive:post:any', (string) Tag::archive('post')->qualify('any'));
+    }
+
+    public function test_scope_is_general_and_composes_for_nested_dimensions(): void
+    {
+        // Replaces the site-only withScope(int): any dimension, any depth.
+        $this->assertSame('site:7:post:123', (string) Tag::post(123)->scope('site', 7));
+        $this->assertSame(
+            'network:2:site:5:post:123',
+            (string) Tag::post(123)->scope('network', 2)->scope('site', 5),
+            'scopes nest outer→inner in call order'
+        );
+        $this->assertSame('site:7:custom:thing', (string) Tag::of('custom', 'thing')->scope('site', 7));
+    }
+
+    public function test_parse_extracts_structured_fields_and_scope(): void
     {
         $tag = Tag::parse('site:5:post:123');
         $this->assertSame('post', $tag->type);
-        $this->assertSame(123, $tag->identifier);
-        $this->assertSame(5, $tag->scope);
+        $this->assertSame(123, $tag->id);
+        $this->assertSame([['site', 5]], $tag->scopes);
         $this->assertNull($tag->qualifier);
-        $this->assertFalse($tag->isRaw());
 
-        $archive = Tag::parse('archive:product:any');
-        $this->assertSame('archive', $archive->type);
-        $this->assertSame('product', $archive->identifier);
-        $this->assertSame('any', $archive->qualifier);
+        $nested = Tag::parse('network:2:site:5:archive:post:any');
+        $this->assertSame('archive', $nested->type);
+        $this->assertSame('post', $nested->id);
+        $this->assertSame('any', $nested->qualifier);
+        $this->assertSame([['network', 2], ['site', 5]], $nested->scopes);
     }
 
-    public function test_unknown_strings_are_raw_and_round_trip(): void
+    public function test_a_bare_scope_dimension_tag_is_not_mistaken_for_a_prefix(): void
     {
-        $tag = Tag::parse('my:custom:tag');
-        $this->assertTrue($tag->isRaw());
-        $this->assertSame('my:custom:tag', $tag->raw);
-        $this->assertSame('my:custom:tag', (string) $tag);
-
-        // A malformed known type is treated as raw, not silently coerced.
-        $this->assertTrue(Tag::parse('post:not-a-number')->isRaw());
-    }
-
-    public function test_scope_applies_to_structured_and_raw_tags(): void
-    {
-        $this->assertSame('site:7:post:123', (string) Tag::post(123)->withScope(7));
-        $this->assertSame('site:7:my:custom', (string) Tag::raw('my:custom')->withScope(7));
-        // withScope(null) removes a scope.
-        $this->assertSame('post:123', (string) Tag::parse('site:7:post:123')->withScope(null));
+        // "site:5" is the site tag itself, not an empty-bodied scope.
+        $tag = Tag::parse('site:5');
+        $this->assertSame('site', $tag->type);
+        $this->assertSame(5, $tag->id);
+        $this->assertSame([], $tag->scopes);
     }
 
     public function test_from_accepts_strings_and_tags(): void

--- a/tests/unit/test-tag.php
+++ b/tests/unit/test-tag.php
@@ -1,0 +1,104 @@
+<?php
+
+use Genero\Sage\CacheTags\Tag;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Tag
+ */
+class TestTag extends WP_UnitTestCase
+{
+    /** @return iterable<string, array{0: string}> */
+    public function tagStrings(): iterable
+    {
+        // Every shape the codebase produces must round-trip through parse + cast.
+        yield 'post' => ['post:123'];
+        yield 'term' => ['term:9'];
+        yield 'term full' => ['term:9:full'];
+        yield 'user' => ['user:4'];
+        yield 'comment' => ['comment:7'];
+        yield 'menu' => ['menu:2'];
+        yield 'gform' => ['gform:5'];
+        yield 'site' => ['site:1'];
+        yield 'archive' => ['archive:post'];
+        yield 'archive any' => ['archive:product:any'];
+        yield 'archive lang' => ['archive:post:fi'];
+        yield 'taxonomy' => ['taxonomy:category'];
+        yield 'taxonomy any' => ['taxonomy:category:any'];
+        yield 'role' => ['role:editor'];
+        yield 'option' => ['option:blogname'];
+        yield 'lang' => ['lang:sv'];
+        yield 'nonce' => ['nonce'];
+        // Multisite "site:N:" scope prefixes.
+        yield 'scoped post' => ['site:5:post:123'];
+        yield 'scoped archive any' => ['site:5:archive:post:any'];
+        yield 'scoped term full' => ['site:2:term:9:full'];
+        // A site's own custom tags must survive verbatim.
+        yield 'custom' => ['my:custom:tag'];
+        yield 'custom single' => ['banner'];
+        yield 'scoped custom' => ['site:3:my:custom:tag'];
+    }
+
+    /**
+     * @dataProvider tagStrings
+     */
+    public function test_parse_and_cast_round_trip(string $string): void
+    {
+        $this->assertSame($string, (string) Tag::parse($string));
+    }
+
+    public function test_builders_serialize_to_the_expected_strings(): void
+    {
+        $this->assertSame('post:123', (string) Tag::post(123));
+        $this->assertSame('term:9:full', (string) Tag::term(9)->full());
+        $this->assertSame('archive:post', (string) Tag::archive('post'));
+        $this->assertSame('archive:post:any', (string) Tag::archive('post')->any());
+        $this->assertSame('archive:post:fi', (string) Tag::archive('post')->inLanguage('fi'));
+        $this->assertSame('taxonomy:category:any', (string) Tag::taxonomy('category')->any());
+        $this->assertSame('role:editor', (string) Tag::role('editor'));
+        $this->assertSame('option:blogname', (string) Tag::option('blogname'));
+        $this->assertSame('lang:fi', (string) Tag::language('fi'));
+        $this->assertSame('nonce', (string) Tag::nonce());
+        $this->assertSame('site:1', (string) Tag::site(1));
+    }
+
+    public function test_parse_extracts_structured_fields(): void
+    {
+        $tag = Tag::parse('site:5:post:123');
+        $this->assertSame('post', $tag->type);
+        $this->assertSame(123, $tag->identifier);
+        $this->assertSame(5, $tag->scope);
+        $this->assertNull($tag->qualifier);
+        $this->assertFalse($tag->isRaw());
+
+        $archive = Tag::parse('archive:product:any');
+        $this->assertSame('archive', $archive->type);
+        $this->assertSame('product', $archive->identifier);
+        $this->assertSame('any', $archive->qualifier);
+    }
+
+    public function test_unknown_strings_are_raw_and_round_trip(): void
+    {
+        $tag = Tag::parse('my:custom:tag');
+        $this->assertTrue($tag->isRaw());
+        $this->assertSame('my:custom:tag', $tag->raw);
+        $this->assertSame('my:custom:tag', (string) $tag);
+
+        // A malformed known type is treated as raw, not silently coerced.
+        $this->assertTrue(Tag::parse('post:not-a-number')->isRaw());
+    }
+
+    public function test_scope_applies_to_structured_and_raw_tags(): void
+    {
+        $this->assertSame('site:7:post:123', (string) Tag::post(123)->withScope(7));
+        $this->assertSame('site:7:my:custom', (string) Tag::raw('my:custom')->withScope(7));
+        // withScope(null) removes a scope.
+        $this->assertSame('post:123', (string) Tag::parse('site:7:post:123')->withScope(null));
+    }
+
+    public function test_from_accepts_strings_and_tags(): void
+    {
+        $tag = Tag::post(1);
+        $this->assertSame($tag, Tag::from($tag), 'a Tag passes through');
+        $this->assertSame('post:5', (string) Tag::from('post:5'), 'a string is parsed');
+    }
+}


### PR DESCRIPTION
**313 tests green.** What began as #53 + #54 grew into the **v3** release: structured tags throughout, plus a pass over defaults, the bundled providers, and the public surface. Backward compatible with raw custom tag strings; breaking changes are collected in [`UPGRADING.md`](UPGRADING.md). Audited against solarplexius, herrfors, beamex and kaskipuu — each needs only a composer bump.

## #53 — a fluent, general `Tag` used everywhere
A `Tag` value object is the single place a tag string is parsed or serialized (`Tag::parse()` / `__toString()`); the rest of the codebase passes `Tag`s and only serializes at true edges (the header, the store, the invalidators).

```php
Tag::post(5)
Tag::archive('post')->any()
Tag::term(9)->full()
Tag::post(5)->scope('site', 5)                       // multisite
Tag::post(5)->scope('network', 2)->scope('site', 5)  // composes, any depth
Tag::archive('post')->qualify($lang)                 // general trailing variant
Tag::of('gform', 5)                                  // arbitrary types
```

Two general operations (`scope()`/`qualify()`) replace the earlier `withScope(int)`/`inLanguage(string)`, so a new dimension (a multisite *network*, a tenant) needs no new API. All builders (`CoreTags`, `SiteTags`, `PolylangTags`, `WooCommerceTags`, `GravityformTags`) return `Tag[]`; `CacheTags` holds `Tag[]` and collapses-to-budget on Tag fields (the `site:\d+:` regex is gone). `add()`/`clear()` are variadic and accept strings *and* Tags; unrecognised custom strings round-trip verbatim via `Tag::raw`.

## #54 — parallel + hardened Fastly purges
A >256-key purge is chunked (256 is Fastly's documented max) and dispatched **concurrently**, bounded to `MAX_CONCURRENT_PURGES` per window; the single-request common case stays a simple blocking call. Plus, from a doc-backed audit of Fastly's purge API: TLS verification is no longer disabled (it was leaking the API token), and a **429 backoff** retries on rate-limit using `Retry-After` → `Fastly-RateLimit-Reset` → exponential.

## Defaults & actions
- **Base `page` tag** on every cacheable page + REST response (`BaseTag` action, wired from `base-tag`), so `wp cachetags clear page` flushes all WP-served pages while assets stay cached.
- **`Nonce` action** (default-on) owns the twice-daily nonce purge cron — decoupled from Gravity Forms, opt out by removing it.
- **Auto-detect** now enables WooCommerce, Polylang **and Gravity Forms** when active.
- A disabled bootstrap is now fully inert (it no longer scheduled the nonce cron).

## Kinsta
- Bulk purges route to Kinsta's **throttled endpoint** (server-side coalescing) instead of escalating to a full-site flush (which is rate-limited 1/10s and stampede-prone).
- MU-plugin purge failures are now logged — the only client-side signal of endpoint backpressure (downstream edge throttling is invisible by design).
- `KinstaGroupCacheInvalidator` is documented as the recommended setup (prefix purges cut purge volume — the real defense against edge rate limits).

## Public surface trimmed
- `cachetags/filter-tags` now passes `Tag[]` (was `string[]`) — the only released filter whose signature changed; removes the serialize→filter→re-parse round-trip and lets `Site`/`Polylang` transform Tags directly.
- Removed the unreleased `max-tag-length` / `max-url-length` / `tag-pattern` filters (hardcoded to the schema/header invariants) and the speculative `cachetags/purged` / `cachetags/flushed` hooks.

Closes #53, #54. See `UPGRADING.md` for the full v3 migration notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
