### PR TITLE
Store garbage collection: prune cache_tags by last-seen (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,9 @@ wp acorn cachetags:database --rebuild
 wp acorn cachetags:status
 # …or the tags a given URL is stored under
 wp acorn cachetags:status --url=https://example.com/article/
+
+# Garbage-collect store rows not re-rendered within the age (see note below)
+wp acorn cachetags:prune --older-than=30d
 ```
 
 **Standalone:**
@@ -617,11 +620,22 @@ wp cachetags database --rebuild
 # Inspect the store
 wp cachetags status
 wp cachetags status --url=https://example.com/article/
+
+# Garbage-collect store rows not re-rendered within the age (see note below)
+wp cachetags prune --older-than=30d
 ```
 
 `status` answers "what's bloating the store / why was this purged so widely" — a
 tag with a high URL count purges that many pages on a single change. It requires
 a store that supports inspection (the default `WordpressDbStore` does).
+
+`prune` garbage-collects store rows whose URL hasn't been rendered within the
+given age (`12h`/`30d`/`4w`) — query-string, bot and campaign-link variants that
+otherwise accumulate forever, especially on query-bypass edges. A row's age is
+*last seen* (refreshed on each render), so actively-served pages are never pruned.
+**The age must exceed your edge cache's max TTL** — pruning a URL still cached at
+the edge leaves an object you can no longer purge by tag. Pruning is manual; the
+default `WordpressDbStore` supports it (the in-memory `TransientStore` doesn't).
 
 The store is a rebuildable cache, so `--rebuild` migrates an existing (even
 million-row) table to the latest schema by dropping and recreating it — avoiding

--- a/README.md
+++ b/README.md
@@ -632,10 +632,16 @@ a store that supports inspection (the default `WordpressDbStore` does).
 `prune` garbage-collects store rows whose URL hasn't been rendered within the
 given age (`12h`/`30d`/`4w`) — query-string, bot and campaign-link variants that
 otherwise accumulate forever, especially on query-bypass edges. A row's age is
-*last seen* (refreshed on each render), so actively-served pages are never pruned.
-**The age must exceed your edge cache's max TTL** — pruning a URL still cached at
-the edge leaves an object you can no longer purge by tag. Pruning is manual; the
-default `WordpressDbStore` supports it (the in-memory `TransientStore` doesn't).
+*last seen* (refreshed on each render, at most once a day to avoid write churn),
+so actively-served pages are never pruned.
+
+This **runs daily by default** (the `prune-older-than` config, default `30d`) — the
+manual command above just forces a run. **The age must exceed your edge cache's
+max TTL**: pruning a URL still cached at the edge leaves an object you can no
+longer purge by tag (on Kinsta/Fastly the max TTL is ~30d, so raise it if your
+edge holds objects that long). Disable GC with `'prune-older-than' => null`. Only
+a prunable store (the default `WordpressDbStore`) is affected — `TransientStore`
+no-ops.
 
 The store is a rebuildable cache, so `--rebuild` migrates an existing (even
 million-row) table to the latest schema by dropping and recreating it — avoiding

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -110,6 +110,17 @@ this replaces the trick of enabling the `Site` action just to get a flush-all ke
   theme's own, is covered without wiring a cron. Opt out by removing `Nonce::class`
   from `action`.
 
+### New default: store garbage collection
+
+The `WordpressDbStore` now garbage-collects itself: a daily cron prunes rows whose
+URL hasn't rendered within `'prune-older-than'` (default `30d`), so query-string /
+bot / campaign-link variants don't accumulate forever. To make this safe, `save()`
+switched from `INSERT IGNORE` to an upsert that refreshes a row's `created_at`
+("last seen") at most once a day — so a frequently-rendered URL isn't written on
+every cache miss, and live pages are never pruned. **Set `'prune-older-than'` above
+your edge cache's max TTL** (≈30d on Kinsta/Fastly), or disable GC with
+`'prune-older-than' => null`. `wp cachetags prune --older-than=…` runs it manually.
+
 ### Unchanged
 
 Compatible without changes: `CacheTags::add/clear/save/flush/getInstance/hasAction`

--- a/config/cachetags.php
+++ b/config/cachetags.php
@@ -27,6 +27,13 @@ return [
     // BaseTag action automatically from this value — it isn't listed in 'action'.)
     'base-tag' => 'page',
 
+    // Daily store garbage collection: prune cache_tags rows whose URL hasn't been
+    // rendered within this age (12h / 30d / 4w), so query-string / bot / campaign
+    // variants don't accumulate forever. A row's age is "last seen", so live pages
+    // are never pruned. MUST exceed your edge cache's max TTL — pruning a URL still
+    // cached at the edge leaves an object you can't purge by tag. null to disable.
+    'prune-older-than' => '30d',
+
     'action' => [
         Core::class,
         DebugComment::class,

--- a/src/Actions/PruneStore.php
+++ b/src/Actions/PruneStore.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Actions;
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Contracts\Action;
+use Genero\Sage\CacheTags\PruneCron;
+
+/**
+ * Schedule the daily store garbage collection (prune cache_tags rows not
+ * re-rendered within `age`), so the store doesn't accumulate URLs that never
+ * re-render — query-string / bot / campaign variants, dead permalinks.
+ *
+ * On by default; wired by Bootstrap with the configured age. Set the base age to
+ * null (config `prune-older-than`) to opt out. The age MUST exceed the edge
+ * cache's max TTL — pruning a URL still cached at the edge leaves an object that
+ * can no longer be purged by tag.
+ */
+class PruneStore implements Action
+{
+    public function __construct(protected CacheTags $cacheTags, protected string $age = '30d') {}
+
+    public function bind(): void
+    {
+        PruneCron::register($this->age);
+    }
+}

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -203,6 +203,7 @@ class Bootstrap
         \WP_CLI::add_command('cachetags flush', WpCli\FlushCommand::class);
         \WP_CLI::add_command('cachetags clear', WpCli\ClearCommand::class);
         \WP_CLI::add_command('cachetags status', WpCli\StatusCommand::class);
+        \WP_CLI::add_command('cachetags prune', WpCli\PruneCommand::class);
     }
 
     protected function bindActions(): void

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -52,6 +52,7 @@ class Bootstrap
         protected array $actions = [Core::class],
         protected bool $autoDetectActions = true,
         protected ?string $baseTag = 'page',
+        protected ?string $pruneOlderThan = '30d',
     ) {
         $this->debug = $debug ?? (defined('WP_DEBUG') ? WP_DEBUG : false);
     }
@@ -140,6 +141,17 @@ class Bootstrap
     }
 
     /**
+     * Set (or disable, with null) the age past which store rows not re-rendered
+     * are garbage-collected daily. Default "30d"; must exceed the edge cache TTL.
+     */
+    public function pruneOlderThan(?string $age): static
+    {
+        $this->pruneOlderThan = $age;
+
+        return $this;
+    }
+
+    /**
      * Bootstrap CacheTags and return the instance.
      */
     public function bootstrap(): CacheTags
@@ -180,14 +192,17 @@ class Bootstrap
             add_filter('rest_post_dispatch', [$this, 'saveCacheTagsRest'], 10, 3);
             add_action('shutdown', [$this, 'purgeCacheTags']);
 
-            // The Nonce action owns the nonce purge cron and registers it in
-            // bind(); clean up the orphaned schedule when it's removed from the
-            // action set (opt-out).
+            // The Nonce / PruneStore actions own their crons and register them in
+            // bind(); clean up an orphaned schedule when either is opted out.
             if (! $this->cacheTags->hasAction(Actions\Nonce::class)) {
                 NonceCron::unschedule();
             }
+            if (! $this->cacheTags->hasAction(Actions\PruneStore::class)) {
+                PruneCron::unschedule();
+            }
         } else {
             NonceCron::unschedule();
+            PruneCron::unschedule();
         }
 
         return $this->cacheTags;
@@ -221,6 +236,12 @@ class Bootstrap
         // configured tag name, so a single purge clears all WP-served pages.
         if ($this->baseTag) {
             $actions[] = new Actions\BaseTag($this->cacheTags, $this->baseTag);
+        }
+
+        // Daily store garbage collection (unless disabled with prune-older-than:
+        // null) — bound with the configured age.
+        if ($this->pruneOlderThan !== null) {
+            $actions[] = new Actions\PruneStore($this->cacheTags, $this->pruneOlderThan);
         }
 
         foreach ($actions as $action) {

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags;
 
 use Genero\Sage\CacheTags\Contracts\Action;
 use Genero\Sage\CacheTags\Contracts\Invalidator;
+use Genero\Sage\CacheTags\Contracts\PrunableStore;
 use Genero\Sage\CacheTags\Contracts\Store;
 use WP_Term;
 
@@ -352,6 +353,17 @@ class CacheTags
         }
 
         return $result;
+    }
+
+    /**
+     * Garbage-collect store entries last seen before $olderThan. Returns the rows
+     * removed, or null when the active store doesn't support pruning.
+     */
+    public function prune(\DateTimeInterface $olderThan, int $batch = 1000): ?int
+    {
+        return $this->store instanceof PrunableStore
+            ? $this->store->prune($olderThan, $batch)
+            : null;
     }
 
     protected function logFailure(string $message): void

--- a/src/CacheTagsServiceProvider.php
+++ b/src/CacheTagsServiceProvider.php
@@ -5,6 +5,7 @@ namespace Genero\Sage\CacheTags;
 use Genero\Sage\CacheTags\Console\ClearCommand;
 use Genero\Sage\CacheTags\Console\DatabaseCommand;
 use Genero\Sage\CacheTags\Console\FlushCommand;
+use Genero\Sage\CacheTags\Console\PruneCommand;
 use Genero\Sage\CacheTags\Console\StatusCommand;
 use Genero\Sage\CacheTags\Stores\WordpressDbStore;
 use Illuminate\Support\ServiceProvider;
@@ -34,6 +35,7 @@ class CacheTagsServiceProvider extends ServiceProvider
             FlushCommand::class,
             ClearCommand::class,
             StatusCommand::class,
+            PruneCommand::class,
         ]);
     }
 

--- a/src/CacheTagsServiceProvider.php
+++ b/src/CacheTagsServiceProvider.php
@@ -52,6 +52,7 @@ class CacheTagsServiceProvider extends ServiceProvider
             actions: $config->get('cachetags.action', []),
             autoDetectActions: $config->get('cachetags.auto-detect-actions', true),
             baseTag: $config->get('cachetags.base-tag', 'page'),
+            pruneOlderThan: $config->get('cachetags.prune-older-than', '30d'),
         );
 
         return $bootstrap;

--- a/src/Concerns/CreatesDatabaseTable.php
+++ b/src/Concerns/CreatesDatabaseTable.php
@@ -21,6 +21,10 @@ trait CreatesDatabaseTable
 
     /**
      * The current table definition.
+     *
+     * `created_at` is "last seen": WordpressDbStore::save() bumps it on every
+     * re-store, so store garbage collection can prune by it (rows untouched for
+     * longer than the edge TTL) without deleting still-live entries.
      */
     protected function tableSchema(): string
     {

--- a/src/Console/PruneCommand.php
+++ b/src/Console/PruneCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Console;
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Util;
+use Roots\Acorn\Console\Commands\Command;
+
+class PruneCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $name = 'cachetags:prune';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Garbage-collect stale entries from the cache-tag store';
+
+    protected $signature = 'cachetags:prune
+        {--older-than=30d : Age threshold — hours/days/weeks, e.g. 12h, 30d, 4w. Must exceed the edge TTL.}
+        {--batch=1000 : Rows to delete per query}';
+
+    public function handle(): int
+    {
+        $cacheTags = $this->app->make(CacheTags::class);
+
+        $age = (string) $this->option('older-than');
+        $cutoff = Util::cutoffFromAge($age);
+        if ($cutoff === null) {
+            $this->error("Invalid --older-than '{$age}'; use e.g. 12h, 30d, 4w.");
+
+            return self::FAILURE;
+        }
+
+        $removed = $cacheTags->prune($cutoff, (int) $this->option('batch'));
+
+        if ($removed === null) {
+            $this->error('The active store ('.get_class($cacheTags->store).') does not support pruning.');
+
+            return self::FAILURE;
+        }
+
+        $this->info(sprintf('Pruned %d store row(s) older than %s.', $removed, $age));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Contracts/PrunableStore.php
+++ b/src/Contracts/PrunableStore.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Contracts;
+
+use DateTimeInterface;
+
+/**
+ * A store whose entries can be garbage-collected by age. Optional — the prune
+ * command and cron degrade gracefully (no-op) when the active store doesn't
+ * implement it (e.g. the in-memory TransientStore).
+ *
+ * "Age" is last-seen: a store implementing this must bump an entry's timestamp
+ * whenever it's re-stored, so an actively-rendered URL is never pruned. The cutoff
+ * must exceed the edge cache's max TTL, or a still-cached page could be pruned and
+ * left unpurgeable.
+ */
+interface PrunableStore
+{
+    /**
+     * Delete entries last stored before $olderThan, in batches of $batch to avoid
+     * a long table lock. Returns the number of rows removed.
+     */
+    public function prune(DateTimeInterface $olderThan, int $batch = 1000): int;
+}

--- a/src/PruneCron.php
+++ b/src/PruneCron.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Genero\Sage\CacheTags;
+
+/**
+ * WP-Cron scheduler for store garbage collection — deletes cache_tags rows not
+ * re-rendered within the configured age once a day. Owned by the PruneStore
+ * action; the age travels in from config so a change takes effect next request.
+ */
+class PruneCron
+{
+    public const HOOK = 'cachetags_prune_store';
+
+    public static function register(string $age): void
+    {
+        add_action(self::HOOK, function () use ($age) {
+            self::prune($age);
+        });
+
+        if (did_action('init')) {
+            self::schedule();
+        } else {
+            add_action('init', [self::class, 'schedule']);
+        }
+    }
+
+    public static function schedule(): void
+    {
+        if (wp_next_scheduled(self::HOOK)) {
+            return;
+        }
+        wp_schedule_event(time(), 'daily', self::HOOK);
+    }
+
+    public static function unschedule(): void
+    {
+        wp_clear_scheduled_hook(self::HOOK);
+    }
+
+    /**
+     * Cron callback: prune store entries last seen before `age` ago.
+     */
+    public static function prune(string $age): void
+    {
+        $cacheTags = CacheTags::getInstance();
+        $cutoff = Util::cutoffFromAge($age);
+
+        if ($cacheTags === null || $cutoff === null) {
+            return;
+        }
+
+        $cacheTags->prune($cutoff);
+    }
+}

--- a/src/Stores/WordpressDbStore.php
+++ b/src/Stores/WordpressDbStore.php
@@ -2,10 +2,12 @@
 
 namespace Genero\Sage\CacheTags\Stores;
 
+use DateTimeInterface;
 use Genero\Sage\CacheTags\Contracts\InspectableStore;
+use Genero\Sage\CacheTags\Contracts\PrunableStore;
 use Genero\Sage\CacheTags\Contracts\Store;
 
-class WordpressDbStore implements InspectableStore, Store
+class WordpressDbStore implements InspectableStore, PrunableStore, Store
 {
     /**
      * @param  string[]  $tags
@@ -24,9 +26,21 @@ class WordpressDbStore implements InspectableStore, Store
             $values[] = $url;
         }
 
+        // Upsert, refreshing created_at so it tracks "last seen" — that's what
+        // makes pruning by it safe (a still-rendered URL keeps a fresh timestamp
+        // and survives GC; with INSERT IGNORE the timestamp never moved, so GC
+        // would have deleted live entries the edge still holds).
+        //
+        // But refresh at most once a day: bumping on every render would write the
+        // row on every cache miss and hammer the DB. When the row was seen within
+        // the last day the UPDATE sets created_at to itself — a no-op InnoDB skips
+        // (no write). GC TTLs are measured in weeks, so a day of slack is free.
         $result = $wpdb->query($wpdb->prepare("
-            INSERT IGNORE INTO `{$wpdb->prefix}cache_tags` (`tag`, `url`)
+            INSERT INTO `{$wpdb->prefix}cache_tags` (`tag`, `url`)
             VALUES {$placeholders}
+            ON DUPLICATE KEY UPDATE created_at = IF(
+                created_at < (NOW() - INTERVAL 1 DAY), NOW(), created_at
+            )
         ", ...$values));
 
         return $result !== false;
@@ -91,6 +105,38 @@ class WordpressDbStore implements InspectableStore, Store
         return $wpdb->query("
             TRUNCATE `{$wpdb->prefix}cache_tags`
         ") !== false;
+    }
+
+    /**
+     * Garbage-collect rows last stored (created_at) before $olderThan, batched so
+     * a large prune doesn't hold a long lock. Safe because save() bumps created_at
+     * on every re-store, so a still-rendered URL keeps a fresh timestamp.
+     *
+     * @return int rows removed
+     */
+    public function prune(DateTimeInterface $olderThan, int $batch = 1000): int
+    {
+        global $wpdb;
+
+        $cutoff = $olderThan->format('Y-m-d H:i:s');
+        $batch = max(1, $batch);
+        $removed = 0;
+
+        do {
+            $deleted = $wpdb->query($wpdb->prepare("
+                DELETE FROM `{$wpdb->prefix}cache_tags`
+                WHERE created_at < %s
+                LIMIT %d
+            ", $cutoff, $batch));
+
+            if ($deleted === false) {
+                break;
+            }
+
+            $removed += $deleted;
+        } while ($deleted === $batch);
+
+        return $removed;
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -108,6 +108,21 @@ class Util
     const MAX_LENGTH = 191;
 
     /**
+     * Parse a human age like "30d", "12h" or "4w" (hours/days/weeks) into the
+     * cutoff datetime that many units ago. Null if the format isn't recognised.
+     */
+    public static function cutoffFromAge(string $age): ?\DateTimeImmutable
+    {
+        if (! preg_match('/^\s*(\d+)\s*([hdw])\s*$/i', $age, $match)) {
+            return null;
+        }
+
+        $units = ['h' => 'hours', 'd' => 'days', 'w' => 'weeks'];
+
+        return new \DateTimeImmutable("-{$match[1]} {$units[strtolower($match[2])]}");
+    }
+
+    /**
      * Whether a value is a usable cache tag: a non-empty, single header token
      * (no whitespace or control characters) that fits the store column.
      *

--- a/src/WpCli/PruneCommand.php
+++ b/src/WpCli/PruneCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Genero\Sage\CacheTags\WpCli;
+
+use Genero\Sage\CacheTags\CacheTags;
+use Genero\Sage\CacheTags\Util;
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Garbage-collect stale entries from the cache-tag store.
+ */
+class PruneCommand extends WP_CLI_Command
+{
+    /**
+     * Delete store entries not re-stored within the given age.
+     *
+     * Entries refresh their timestamp on every render, so this removes only URLs
+     * that haven't rendered in the window — typically query-string / bot /
+     * campaign variants that accumulate forever otherwise. SAFE ONLY when the age
+     * exceeds your edge cache's max TTL: pruning a URL still cached at the edge
+     * leaves an object you can no longer purge by tag.
+     *
+     * ## OPTIONS
+     *
+     * [--older-than=<age>]
+     * : Age threshold — hours/days/weeks, e.g. 12h, 30d, 4w.
+     * ---
+     * default: 30d
+     * ---
+     *
+     * [--batch=<n>]
+     * : Rows to delete per query (keeps the lock short on large stores).
+     * ---
+     * default: 1000
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     $ wp cachetags prune --older-than=30d
+     *     Success: Pruned 4123 store row(s) older than 30d.
+     *
+     * @param  string[]  $args
+     * @param  array<string, string>  $assoc
+     */
+    public function __invoke($args, $assoc): void
+    {
+        $cacheTags = CacheTags::getInstance();
+        if ($cacheTags === null) {
+            WP_CLI::error('CacheTags has not been bootstrapped.');
+        }
+
+        $age = $assoc['older-than'] ?? '30d';
+        $cutoff = Util::cutoffFromAge($age);
+        if ($cutoff === null) {
+            WP_CLI::error("Invalid --older-than '{$age}'; use e.g. 12h, 30d, 4w.");
+        }
+
+        $removed = $cacheTags->prune($cutoff, (int) ($assoc['batch'] ?? 1000));
+
+        if ($removed === null) {
+            WP_CLI::error('The active store ('.get_class($cacheTags->store).') does not support pruning.');
+        }
+
+        WP_CLI::success(sprintf('Pruned %d store row(s) older than %s.', $removed, $age));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,7 @@ tests_add_filter('muplugins_loaded', function (): void {
         ->actions([Core::class, HttpHeader::class, RestApi::class])
         ->autoDetectActions(false)
         ->baseTag(null) // tested in isolation; keep it out of the shared tag set
+        ->pruneOlderThan(null) // tested in isolation; no stray prune cron
         ->bootstrap();
 
     // The activation hook does not run in the test environment, so create the

--- a/tests/integration/test-bootstrap.php
+++ b/tests/integration/test-bootstrap.php
@@ -5,12 +5,14 @@ use Genero\Sage\CacheTags\Actions\Core;
 use Genero\Sage\CacheTags\Actions\Gravityform;
 use Genero\Sage\CacheTags\Actions\Nonce;
 use Genero\Sage\CacheTags\Actions\Polylang;
+use Genero\Sage\CacheTags\Actions\PruneStore;
 use Genero\Sage\CacheTags\Actions\WooCommerce;
 use Genero\Sage\CacheTags\Bootstrap;
 use Genero\Sage\CacheTags\CacheTags;
 use Genero\Sage\CacheTags\Contracts\Store;
 use Genero\Sage\CacheTags\Invalidators\DebugCacheInvalidator;
 use Genero\Sage\CacheTags\NonceCron;
+use Genero\Sage\CacheTags\PruneCron;
 use Genero\Sage\CacheTags\Stores\TransientStore;
 
 /**
@@ -101,6 +103,32 @@ class TestBootstrap extends WP_UnitTestCase
 
         $this->assertNotFalse(wp_next_scheduled(NonceCron::HOOK));
         NonceCron::unschedule();
+    }
+
+    public function test_prune_store_action_is_bound_by_default_and_schedules_the_cron(): void
+    {
+        PruneCron::unschedule();
+
+        // Default prune-older-than ('30d') binds PruneStore, which schedules GC.
+        $cacheTags = (new Bootstrap)->store(TransientStore::class)->actions([])->autoDetectActions(false)->bootstrap();
+
+        $this->assertTrue($cacheTags->hasAction(PruneStore::class), 'GC on by default');
+        $this->assertNotFalse(wp_next_scheduled(PruneCron::HOOK));
+        PruneCron::unschedule();
+    }
+
+    public function test_prune_can_be_disabled_and_unschedules_the_cron(): void
+    {
+        PruneCron::register('30d'); // pretend a schedule already exists
+        $this->assertNotFalse(wp_next_scheduled(PruneCron::HOOK));
+
+        $cacheTags = (new Bootstrap)
+            ->store(TransientStore::class)->actions([])->autoDetectActions(false)
+            ->pruneOlderThan(null)
+            ->bootstrap();
+
+        $this->assertFalse($cacheTags->hasAction(PruneStore::class), 'opted out');
+        $this->assertFalse(wp_next_scheduled(PruneCron::HOOK), 'orphaned cron cleaned up');
     }
 
     public function test_save_cache_tags_stores_a_cacheable_front_end_url(): void

--- a/tests/integration/test-store.php
+++ b/tests/integration/test-store.php
@@ -1,7 +1,9 @@
 <?php
 
+use Genero\Sage\CacheTags\Contracts\PrunableStore;
 use Genero\Sage\CacheTags\Stores\TransientStore;
 use Genero\Sage\CacheTags\Stores\WordpressDbStore;
+use Genero\Sage\CacheTags\Util;
 
 /**
  * @covers \Genero\Sage\CacheTags\Stores\WordpressDbStore
@@ -85,5 +87,63 @@ class TestStore extends WP_UnitTestCase
 
         $this->assertEqualsCanonicalizing(['post:1', 'archive:post'], $store->tagsForUrl('/a/'));
         $this->assertSame([], $store->tagsForUrl('/missing/'));
+    }
+
+    public function test_prune_removes_rows_older_than_the_cutoff(): void
+    {
+        global $wpdb;
+        $store = new WordpressDbStore;
+        $store->flush();
+        $store->save(['post:1'], '/stale/');
+        $store->save(['post:2'], '/fresh/');
+
+        // Backdate the stale row's last-seen to 40 days ago.
+        $wpdb->query("UPDATE {$wpdb->prefix}cache_tags SET created_at = (NOW() - INTERVAL 40 DAY) WHERE url = '/stale/'");
+
+        $removed = $store->prune(new DateTimeImmutable('-30 days'));
+
+        $this->assertSame(1, $removed, 'one stale row removed, the recent one kept');
+        $this->assertSame([], $store->get(['post:1']));
+        $this->assertSame(['/fresh/'], $store->get(['post:2']));
+    }
+
+    public function test_save_refreshes_last_seen_only_once_per_day(): void
+    {
+        global $wpdb;
+        $store = new WordpressDbStore;
+        $store->flush();
+        $store->save(['post:1'], '/a/');
+
+        $seenAt = fn () => $wpdb->get_var("SELECT created_at FROM {$wpdb->prefix}cache_tags WHERE url = '/a/'");
+        $first = $seenAt();
+
+        // A re-store within the day must NOT move the timestamp (no write churn).
+        $store->save(['post:1'], '/a/');
+        $this->assertSame($first, $seenAt(), 'unchanged within the refresh window');
+
+        // Once it's older than a day, the next store refreshes it.
+        $wpdb->query("UPDATE {$wpdb->prefix}cache_tags SET created_at = (NOW() - INTERVAL 2 DAY) WHERE url = '/a/'");
+        $staleValue = $seenAt();
+        $store->save(['post:1'], '/a/');
+        $this->assertGreaterThan($staleValue, $seenAt(), 'refreshed to now once stale');
+    }
+
+    public function test_only_the_db_store_is_prunable(): void
+    {
+        $this->assertInstanceOf(PrunableStore::class, new WordpressDbStore);
+        $this->assertNotInstanceOf(PrunableStore::class, new TransientStore);
+    }
+
+    public function test_cutoff_from_age_parses_hours_days_weeks(): void
+    {
+        $this->assertNull(Util::cutoffFromAge('soon'));
+        $this->assertNull(Util::cutoffFromAge('30'));
+
+        // 30d ago is ~30*24h before now (allow a second of slack).
+        $delta = (new DateTimeImmutable)->getTimestamp() - Util::cutoffFromAge('30d')->getTimestamp();
+        $this->assertEqualsWithDelta(30 * 86400, $delta, 5);
+
+        $this->assertEqualsWithDelta(12 * 3600, (new DateTimeImmutable)->getTimestamp() - Util::cutoffFromAge('12h')->getTimestamp(), 5);
+        $this->assertEqualsWithDelta(4 * 7 * 86400, (new DateTimeImmutable)->getTimestamp() - Util::cutoffFromAge('4w')->getTimestamp(), 5);
     }
 }


### PR DESCRIPTION
Closes #48. **319 tests green.**

`WordpressDbStore` rows only disappeared on a tag purge, so URLs that are never re-rendered (query-string / bot / campaign variants — pure waste on query-bypass edges) accumulated forever. The schema already had `created_at`, but nothing read it.

## Making `created_at` safe to prune by
GC by `created_at` is only safe if it means **last seen**, not first inserted — otherwise a URL still cached at the edge (but whose row is old) gets pruned, and a later tag purge can't resolve it to a URL → stale content.

- `save()` now upserts and refreshes `created_at` (`ON DUPLICATE KEY UPDATE`). With the old `INSERT IGNORE` the timestamp never moved.
- **No write amplification:** it refreshes at most once a day — within the window the update is `created_at = created_at`, a no-op InnoDB skips, so a frequently-rendered URL isn't written on every cache miss. GC TTLs are weeks, so a day of slack is free.

## The GC
- `Contracts\PrunableStore` (optional; `TransientStore` degrades gracefully).
- `WordpressDbStore::prune(\DateTimeInterface $olderThan, int $batch = 1000)` — batched `DELETE … WHERE created_at < … LIMIT …`.
- `CacheTags::prune()` — rows removed, or `null` when the store isn't prunable.
- `wp cachetags prune --older-than=30d` (standalone + Acorn) + `Util::cutoffFromAge()` (`12h`/`30d`/`4w`).

## Daily cron — on by default, opt out
- A **`PruneStore` action** (config-wired from `prune-older-than`, default `30d`, like `BaseTag`) schedules a daily `PruneCron`. On by default; opt out with `'prune-older-than' => null` — Bootstrap then unschedules the orphaned cron (same pattern as the `Nonce` action). A disabled bootstrap unschedules both crons.

## Safety
The age **must exceed the edge cache's max TTL** (≈30d on Kinsta/Fastly) — pruning a URL still cached at the edge leaves an object you can't purge by tag. The once-a-day `created_at` refresh keeps actively-served pages safe. Documented on the config key, the action, the CLI command, README and UPGRADING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)