### PR TITLE
Opt-in Fastly query-param allowlist → Edge Dictionary (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,21 @@ return [
 
 ### Fastly query-param allowlist (edge cache-key normalisation)
 
-Query-string variants fragment the edge cache: `/shop/?orderby=price&fbclid=x`,
-`/shop/?orderby=price&utm_source=…` and `/shop/?orderby=price` are three cached
-objects when they should be one. The fix is an **allowlist** — only
-*cache-significant* params (a WooCommerce attribute filter, a FacetWP facet,
-`orderby`, `s`, …) belong in the cache key; everything else is stripped at the
-edge. But that list is **site-specific and dynamic**, which only WordPress knows.
+**Shrinks the query-string DDoS / cache-busting surface.** An attacker (or a
+runaway bot) can append unbounded unique query params — `?x=1`, `?x=2`, … — to
+force a cache miss on *every* request and hammer the origin. A deny-list of known
+trackers can't stop that (the attacker just uses names that aren't on it); an
+**allowlist** can — only known *cache-significant* params (a WooCommerce attribute
+filter, a FacetWP facet, `orderby`, `s`, …) survive into the cache key, so anything
+unrecognised collapses to the canonical cached object and never reaches origin. It
+de-fragments ordinary tracker/bot noise (`utm_*`, `gclid`) as a bonus. The list is
+**site-specific and dynamic**, which only WordPress knows.
+
+It allowlists param *names* (keeping values) — which covers the main vector
+(random names) and stays within Fastly's dictionary size budget. A high-cardinality
+*allowlisted* key can still be value-busted (notably `s` search — unbounded
+values); cache-bypass or rate-limit those at the edge separately rather than
+enumerating values here.
 
 So the plugin computes the allowlist and syncs it to a Fastly **Edge Dictionary**
 (versionless — updates hit the live edge in ~30s, no deploy), and a small static
@@ -264,9 +273,17 @@ separate allowlist per site.
 > `cachetags/fastly-allowed-query-params` filter:
 
 ```php
+// Add a param the built-ins missed (or drop one they got wrong):
 add_filter('cachetags/fastly-allowed-query-params', function (array $params) {
     $params[] = 'my_custom_facet';
     return $params;
+});
+
+// …or take the last word over the exact list synced to Fastly (edit/add/remove).
+// Runs after the built-ins + the filter above; the result is re-sanitised, so a
+// name with a comma/space/control char can't reach the dictionary.
+add_filter('cachetags/fastly-allowlist', function (array $params) {
+    return array_values(array_diff($params, ['feed', 'author']));
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -210,11 +210,15 @@ VCL snippet reads it and filters the cache key. Opt in by naming the dictionary:
 'fastly-allowlist-dictionary' => 'cachetags_query_allowlist',
 ```
 
+Only relevant when **Fastly is your edge** — it's a cache-key shaping concern, not
+tag purging.
+
 **Setup:**
 
 1. Create an Edge Dictionary named `cachetags_query_allowlist` on your Fastly
-   service (one-time, in the Fastly UI/API). Make sure `FASTLY_SERVICE_ID` /
-   `FASTLY_API_KEY` are set (same env as purging).
+   service (one-time, in the Fastly UI/API). `FASTLY_SERVICE_ID` / `FASTLY_API_KEY`
+   must be set — and the token needs **`write_dictionaries` (global/engineer)
+   scope**, not just purge scope, or `sync` fails with an opaque error.
 2. Add the VCL snippet below to `vcl_recv` (one-time).
 3. Review the computed list and push it:
 
@@ -226,23 +230,37 @@ VCL snippet reads it and filters the cache key. Opt in by naming the dictionary:
 
    Re-run `sync` whenever your attributes/facets change (e.g. from a deploy hook).
 
-**VCL snippet** (`vcl_recv`):
+**VCL snippet** — a complete, drop-in `vcl_recv` block (modelled on the Genero
+Fastly VCLs: same `querystring.filtersep()` idiom, with the tracker deny-list kept
+as a fallback) is at [`examples/fastly-query-allowlist.vcl`](examples/fastly-query-allowlist.vcl).
+The core of it:
 
 ```vcl
 declare local var.allow STRING;
 set var.allow = table.lookup(cachetags_query_allowlist, "params", "");
-if (var.allow != "") {                                  # fail-open until first sync
-  set var.allow = regsuball(var.allow, ",", querystring.filtersep());
-  set req.url = querystring.filter_except(req.url, var.allow);
+if (var.allow != ""                                    # fail-open until first sync
+    && req.method == "GET"
+    && req.url.path !~ "^/(wp|wp-admin|wp-json)/"
+    && req.url !~ "(add-to-cart|remove_item|wc-ajax)=") {   # keep functional params
+  set req.url = querystring.filter_except(req.url, regsuball(var.allow, ",", querystring.filtersep()));
 }
-set req.url = querystring.sort(req.url);                 # canonical param order
+set req.url = querystring.sort(req.url);               # canonical param order
 ```
 
+`querystring.filter_except` rewrites `req.url`, which on a miss is fetched from
+origin — so the guards keep it from stripping functional params (add-to-cart,
+AJAX) or running on admin/non-GET requests before the cache-bypass logic sees
+them. Stripped trackers (`utm_*`, `fbclid`, …) therefore won't reach origin on a
+cache *miss* (client-side GA is unaffected — the browser URL is untouched). The
+example file slots in where a Genero VCL normally does the tracker deny-list +
+`querystring.sort`.
+
 > ⚠️ **An incomplete allowlist serves wrong content.** A param that's stripped but
-> *was* meaningful (a missed facet, `min_price`) collapses real variants into one
-> cached page — silently. This is fail-*dangerous*, unlike the deny-list of known
-> trackers. Always `preview` before `sync`, and add anything the built-ins miss via
-> the `cachetags/fastly-allowed-query-params` filter:
+> *was* meaningful (a missed facet, `min_price`, a custom CPT's `post_type`)
+> collapses real variants into one cached page — silently. This is
+> fail-*dangerous*, unlike the deny-list of known trackers. Always `preview` before
+> `sync`, and add anything the built-ins miss via the
+> `cachetags/fastly-allowed-query-params` filter:
 
 ```php
 add_filter('cachetags/fastly-allowed-query-params', function (array $params) {
@@ -251,9 +269,11 @@ add_filter('cachetags/fastly-allowed-query-params', function (array $params) {
 });
 ```
 
-The built-ins cover core (`s`, `orderby`, `paged`), WooCommerce (attribute filters,
-price, rating) and FacetWP facets. Syncing is manual (CLI) — wire it to a deploy
-hook if you want it automated.
+The built-ins cover core (`s`, `post_type`, `orderby`, `paged`), WooCommerce
+(attribute `filter_*`/`query_type_*`, price, rating, stock, `product-page`),
+FacetWP facets (the `_`-prefixed vars + `_paged`/`_per_page`/`_sort`) and Polylang
+`lang`. Commonly-missed: a theme's custom query vars, `cpage` (comment paging),
+`feed`. Syncing is manual (CLI) — wire it to a deploy hook to automate.
 
 ## REST API integration
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ set var.allow = table.lookup(cachetags_query_allowlist, req.http.host, "");  # p
 if (var.allow != ""                                    # fail-open until first sync
     && req.method == "GET"
     && req.url.path !~ "^/(wp|wp-admin|wp-json)/"
+    && req.url.path !~ "\.php$"                         # wp-login.php, xmlrpc.php, …
     && req.url !~ "(add-to-cart|remove_item|wc-ajax)=") {   # keep functional params
   set req.url = querystring.filter_except(req.url, regsuball(var.allow, ",", querystring.filtersep()));
 }
@@ -259,11 +260,13 @@ set req.url = querystring.sort(req.url);               # canonical param order
 
 `querystring.filter_except` rewrites `req.url`, which on a miss is fetched from
 origin — so the guards keep it from stripping functional params (add-to-cart,
-AJAX) or running on admin/non-GET requests before the cache-bypass logic sees
-them. Stripped trackers (`utm_*`, `fbclid`, …) therefore won't reach origin on a
-cache *miss* (client-side GA is unaffected — the browser URL is untouched). The
-item is keyed by **host**, so a multisite network on one Fastly service keeps a
-separate allowlist per site.
+AJAX) or running on admin / non-GET / `.php` requests (so the `wp-login.php`
+password-reset link `?action=rp&key=…` and login redirects survive) before the
+cache-bypass logic sees them. Stripped trackers (`utm_*`, `fbclid`, …) therefore
+won't reach origin on a cache *miss* (client-side GA is unaffected — the browser
+URL is untouched). The item is keyed by **host**, so a multisite network on one
+Fastly service keeps a separate allowlist per site — run `sync` per site
+(`wp --url=https://site.example cachetags fastly-allowlist sync`).
 
 > ⚠️ **An incomplete allowlist serves wrong content.** A param that's stripped but
 > *was* meaningful (a missed facet, `min_price`, a custom CPT's `post_type`)

--- a/README.md
+++ b/README.md
@@ -192,6 +192,69 @@ return [
 ];
 ````
 
+### Fastly query-param allowlist (edge cache-key normalisation)
+
+Query-string variants fragment the edge cache: `/shop/?orderby=price&fbclid=x`,
+`/shop/?orderby=price&utm_source=…` and `/shop/?orderby=price` are three cached
+objects when they should be one. The fix is an **allowlist** — only
+*cache-significant* params (a WooCommerce attribute filter, a FacetWP facet,
+`orderby`, `s`, …) belong in the cache key; everything else is stripped at the
+edge. But that list is **site-specific and dynamic**, which only WordPress knows.
+
+So the plugin computes the allowlist and syncs it to a Fastly **Edge Dictionary**
+(versionless — updates hit the live edge in ~30s, no deploy), and a small static
+VCL snippet reads it and filters the cache key. Opt in by naming the dictionary:
+
+```php
+// config/cachetags.php  (or ->fastlyAllowlistDictionary('…') standalone)
+'fastly-allowlist-dictionary' => 'cachetags_query_allowlist',
+```
+
+**Setup:**
+
+1. Create an Edge Dictionary named `cachetags_query_allowlist` on your Fastly
+   service (one-time, in the Fastly UI/API). Make sure `FASTLY_SERVICE_ID` /
+   `FASTLY_API_KEY` are set (same env as purging).
+2. Add the VCL snippet below to `vcl_recv` (one-time).
+3. Review the computed list and push it:
+
+   ```sh
+   wp cachetags fastly-allowlist preview   # what WordPress will sync — review it
+   wp cachetags fastly-allowlist sync      # push to the dictionary
+   wp cachetags fastly-allowlist status    # what's at Fastly + in-sync?
+   ```
+
+   Re-run `sync` whenever your attributes/facets change (e.g. from a deploy hook).
+
+**VCL snippet** (`vcl_recv`):
+
+```vcl
+declare local var.allow STRING;
+set var.allow = table.lookup(cachetags_query_allowlist, "params", "");
+if (var.allow != "") {                                  # fail-open until first sync
+  set var.allow = regsuball(var.allow, ",", querystring.filtersep());
+  set req.url = querystring.filter_except(req.url, var.allow);
+}
+set req.url = querystring.sort(req.url);                 # canonical param order
+```
+
+> ⚠️ **An incomplete allowlist serves wrong content.** A param that's stripped but
+> *was* meaningful (a missed facet, `min_price`) collapses real variants into one
+> cached page — silently. This is fail-*dangerous*, unlike the deny-list of known
+> trackers. Always `preview` before `sync`, and add anything the built-ins miss via
+> the `cachetags/fastly-allowed-query-params` filter:
+
+```php
+add_filter('cachetags/fastly-allowed-query-params', function (array $params) {
+    $params[] = 'my_custom_facet';
+    return $params;
+});
+```
+
+The built-ins cover core (`s`, `orderby`, `paged`), WooCommerce (attribute filters,
+price, rating) and FacetWP facets. Syncing is manual (CLI) — wire it to a deploy
+hook if you want it automated.
+
 ## REST API integration
 
 For headless/decoupled setups where pages are served from the WordPress REST

--- a/README.md
+++ b/README.md
@@ -237,13 +237,14 @@ The core of it:
 
 ```vcl
 declare local var.allow STRING;
-set var.allow = table.lookup(cachetags_query_allowlist, "params", "");
+set var.allow = table.lookup(cachetags_query_allowlist, req.http.host, "");  # per-host
 if (var.allow != ""                                    # fail-open until first sync
     && req.method == "GET"
     && req.url.path !~ "^/(wp|wp-admin|wp-json)/"
     && req.url !~ "(add-to-cart|remove_item|wc-ajax)=") {   # keep functional params
   set req.url = querystring.filter_except(req.url, regsuball(var.allow, ",", querystring.filtersep()));
 }
+set req.url = querystring.clean(req.url);              # drop empty params
 set req.url = querystring.sort(req.url);               # canonical param order
 ```
 
@@ -252,8 +253,8 @@ origin — so the guards keep it from stripping functional params (add-to-cart,
 AJAX) or running on admin/non-GET requests before the cache-bypass logic sees
 them. Stripped trackers (`utm_*`, `fbclid`, …) therefore won't reach origin on a
 cache *miss* (client-side GA is unaffected — the browser URL is untouched). The
-example file slots in where a Genero VCL normally does the tracker deny-list +
-`querystring.sort`.
+item is keyed by **host**, so a multisite network on one Fastly service keeps a
+separate allowlist per site.
 
 > ⚠️ **An incomplete allowlist serves wrong content.** A param that's stripped but
 > *was* meaningful (a missed facet, `min_price`, a custom CPT's `post_type`)
@@ -269,11 +270,25 @@ add_filter('cachetags/fastly-allowed-query-params', function (array $params) {
 });
 ```
 
-The built-ins cover core (`s`, `post_type`, `orderby`, `paged`), WooCommerce
-(attribute `filter_*`/`query_type_*`, price, rating, stock, `product-page`),
-FacetWP facets (the `_`-prefixed vars + `_paged`/`_per_page`/`_sort`) and Polylang
-`lang`. Commonly-missed: a theme's custom query vars, `cpage` (comment paging),
-`feed`. Syncing is manual (CLI) — wire it to a deploy hook to automate.
+The built-ins cover WordPress's registered public query vars (core *and* anything
+a theme/plugin registers via the `query_vars` filter, incl. `cpage`/`feed`/ugly
+permalinks), WooCommerce (attribute `filter_*`/`query_type_*`, price, rating,
+stock, `product-page`), FacetWP facets (the `_`-prefixed vars + `_paged`/
+`_per_page`/`_sort`) and Polylang `lang`.
+
+**Operational notes:**
+- **Sync *before* deploying a feature that adds a param.** Dictionary updates
+  propagate in ~30s; in that window a newly-added param is still stripped, and any
+  page cached then stays collapsed until its TTL — so `sync`, confirm with
+  `status`, then ship (and purge the affected pages if you're adding a param).
+- Block-theme **Query Loop pagination** (`?query-{id}-page=`, a dynamic id) can't
+  be enumerated or wildcarded — block-paginated archives won't vary on it.
+- `querystring.sort` leaves the URL unsorted above **32 params** (a Fastly limit) —
+  a corner case for heavily multi-select faceted pages.
+- The allowlist can't exceed Fastly's 8000-char item value (≈230 attributes);
+  `sync` errors clearly if it would.
+
+Syncing is manual (CLI) — wire it to a deploy hook to automate.
 
 ## REST API integration
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -121,6 +121,13 @@ every cache miss, and live pages are never pruned. **Set `'prune-older-than'` ab
 your edge cache's max TTL** (≈30d on Kinsta/Fastly), or disable GC with
 `'prune-older-than' => null`. `wp cachetags prune --older-than=…` runs it manually.
 
+### New (optional): Fastly query-param allowlist
+
+Opt-in (default off). Name a Fastly Edge Dictionary in `'fastly-allowlist-dictionary'`
+and `wp cachetags fastly-allowlist sync` pushes the cache-significant query params
+(WooCommerce/FacetWP/search) to it, for a static VCL snippet to filter the cache
+key. No migration — additive and off by default. See the README.
+
 ### Unchanged
 
 Compatible without changes: `CacheTags::add/clear/save/flush/getInstance/hasAction`

--- a/config/cachetags.php
+++ b/config/cachetags.php
@@ -34,6 +34,13 @@ return [
     // cached at the edge leaves an object you can't purge by tag. null to disable.
     'prune-older-than' => '30d',
 
+    // Opt in to the Fastly query-param allowlist: name the Edge Dictionary the
+    // `wp cachetags fastly-allowlist` commands sync the cache-significant params to
+    // (WooCommerce attributes, FacetWP facets, search, …). A static VCL snippet
+    // reads it and strips every other query param from the cache key, collapsing
+    // tracker/bot noise. null = off. See the README "Fastly query-param allowlist".
+    'fastly-allowlist-dictionary' => null,
+
     'action' => [
         Core::class,
         DebugComment::class,

--- a/examples/fastly-query-allowlist.vcl
+++ b/examples/fastly-query-allowlist.vcl
@@ -26,7 +26,9 @@
 #     plugin can't introspect via the `cachetags/fastly-allowed-query-params` filter.
 
 declare local var.cachetags_allow STRING;
-set var.cachetags_allow = table.lookup(cachetags_query_allowlist, "params", "");
+# Keyed by host: a multisite network on one Fastly service stores one allowlist
+# per host (the plugin syncs per site), so they don't clobber each other.
+set var.cachetags_allow = table.lookup(cachetags_query_allowlist, req.http.host, "");
 
 if (var.cachetags_allow != ""
     && req.method == "GET"
@@ -56,5 +58,8 @@ if (var.cachetags_allow != ""
       "gclid");
 }
 
-# Canonical param order, so ?a=1&b=2 and ?b=2&a=1 share one cached object.
+# Drop empty params (?filter_color=) — classic empty-facet / bot noise — then
+# sort so ?a=1&b=2 and ?b=2&a=1 share one cached object.
+# (To also collapse ?paged=1 ≡ no param, add a regsub for paged/page/_paged=1.)
+set req.url = querystring.clean(req.url);
 set req.url = querystring.sort(req.url);

--- a/examples/fastly-query-allowlist.vcl
+++ b/examples/fastly-query-allowlist.vcl
@@ -4,8 +4,8 @@
 #
 # The plugin syncs the cache-significant query params (WooCommerce attribute
 # filters, FacetWP facets, search, sort, pagination) to an Edge Dictionary named
-# `cachetags_query_allowlist` (one item, key `params`, comma-separated). This keeps
-# only those in the cache key and strips everything else — utm_*, gclid, fbclid,
+# `cachetags_query_allowlist` (one comma-separated item per host). This keeps only
+# those in the cache key and strips everything else — utm_*, gclid, fbclid,
 # bot/session noise — collapsing the variants into one cached object.
 #
 # Setup
@@ -15,10 +15,12 @@
 #      `wp cachetags fastly-allowlist sync`     # push it to the dictionary
 #
 # Safety notes
-#   • The allowlist is authoritative ONLY for cacheable GETs with no functional
-#     params. Add-to-cart / wc-ajax / admin requests keep their full URL so the
-#     downstream `return(pass)` logic still detects them — and so analytics params
-#     reach the origin on those requests.
+#   • The allowlist is authoritative ONLY for cacheable GET HTML requests. PHP
+#     entry points (wp-login.php, wp-cron.php, xmlrpc.php, …), wp-admin/wp-json,
+#     and functional params (add-to-cart, wc-ajax) keep their full URL — so flows
+#     like the password-reset link (?action=rp&key=…) and login redirects aren't
+#     stripped, the downstream `return(pass)` logic still detects them, and
+#     analytics params reach origin on those requests.
 #   • Until the dictionary is synced (empty value), it falls back to the tracker
 #     deny-list below, so behaviour never regresses before the first sync.
 #   • An allowlist that omits a meaningful param silently collapses real variants
@@ -33,6 +35,7 @@ set var.cachetags_allow = table.lookup(cachetags_query_allowlist, req.http.host,
 if (var.cachetags_allow != ""
     && req.method == "GET"
     && req.url.path !~ "^/(wp|wp-admin|wp-json)/"
+    && req.url.path !~ "\.php$"
     && req.url !~ "(add-to-cart|remove_item|undo_item|wc-ajax|show-reset-form)=") {
   # Allowlist: keep only the cache-significant params, drop the rest.
   set req.url = querystring.filter_except(

--- a/examples/fastly-query-allowlist.vcl
+++ b/examples/fastly-query-allowlist.vcl
@@ -1,0 +1,60 @@
+# sage-cachetags — Fastly query-param allowlist (vcl_recv)
+# ─────────────────────────────────────────────────────────
+# Drop-in replacement for the usual "Cleanup and normalize request URL" block.
+#
+# The plugin syncs the cache-significant query params (WooCommerce attribute
+# filters, FacetWP facets, search, sort, pagination) to an Edge Dictionary named
+# `cachetags_query_allowlist` (one item, key `params`, comma-separated). This keeps
+# only those in the cache key and strips everything else — utm_*, gclid, fbclid,
+# bot/session noise — collapsing the variants into one cached object.
+#
+# Setup
+#   1. Create the Edge Dictionary `cachetags_query_allowlist` on the service.
+#   2. Paste this into vcl_recv, replacing the tracker deny-list normalize block.
+#   3. `wp cachetags fastly-allowlist preview`  # review the list
+#      `wp cachetags fastly-allowlist sync`     # push it to the dictionary
+#
+# Safety notes
+#   • The allowlist is authoritative ONLY for cacheable GETs with no functional
+#     params. Add-to-cart / wc-ajax / admin requests keep their full URL so the
+#     downstream `return(pass)` logic still detects them — and so analytics params
+#     reach the origin on those requests.
+#   • Until the dictionary is synced (empty value), it falls back to the tracker
+#     deny-list below, so behaviour never regresses before the first sync.
+#   • An allowlist that omits a meaningful param silently collapses real variants
+#     into one cached page. Always `preview` before `sync`, and add anything the
+#     plugin can't introspect via the `cachetags/fastly-allowed-query-params` filter.
+
+declare local var.cachetags_allow STRING;
+set var.cachetags_allow = table.lookup(cachetags_query_allowlist, "params", "");
+
+if (var.cachetags_allow != ""
+    && req.method == "GET"
+    && req.url.path !~ "^/(wp|wp-admin|wp-json)/"
+    && req.url !~ "(add-to-cart|remove_item|undo_item|wc-ajax|show-reset-form)=") {
+  # Allowlist: keep only the cache-significant params, drop the rest.
+  set req.url = querystring.filter_except(
+    req.url,
+    regsuball(var.cachetags_allow, ",", querystring.filtersep())
+  );
+} else {
+  # Fallback (dictionary not synced yet) and non-cacheable requests: strip only
+  # known trackers — never the functional params the pass logic below relies on.
+  set req.url = querystring.filter(req.url,
+      "utm_source"   + querystring.filtersep() +
+      "utm_id"       + querystring.filtersep() +
+      "utm_term"     + querystring.filtersep() +
+      "utm_medium"   + querystring.filtersep() +
+      "utm_campaign" + querystring.filtersep() +
+      "utm_content"  + querystring.filtersep() +
+      "campaign_id"  + querystring.filtersep() +
+      "gad_source"   + querystring.filtersep() +
+      "wbraid"       + querystring.filtersep() +
+      "_gl"          + querystring.filtersep() +
+      "dclid"        + querystring.filtersep() +
+      "fbclid"       + querystring.filtersep() +
+      "gclid");
+}
+
+# Canonical param order, so ?a=1&b=2 and ?b=2&a=1 share one cached object.
+set req.url = querystring.sort(req.url);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -53,6 +53,7 @@ class Bootstrap
         protected bool $autoDetectActions = true,
         protected ?string $baseTag = 'page',
         protected ?string $pruneOlderThan = '30d',
+        protected ?string $fastlyAllowlistDictionary = null,
     ) {
         $this->debug = $debug ?? (defined('WP_DEBUG') ? WP_DEBUG : false);
     }
@@ -152,6 +153,17 @@ class Bootstrap
     }
 
     /**
+     * Opt in to the Fastly query-param allowlist by naming the Edge Dictionary the
+     * `wp cachetags fastly-allowlist` commands sync to. Null leaves it off.
+     */
+    public function fastlyAllowlistDictionary(?string $dictionary): static
+    {
+        $this->fastlyAllowlistDictionary = $dictionary;
+
+        return $this;
+    }
+
+    /**
      * Bootstrap CacheTags and return the instance.
      */
     public function bootstrap(): CacheTags
@@ -167,6 +179,12 @@ class Bootstrap
                 array_filter($this->invalidators)
             ),
         );
+
+        // Expose the configured Fastly allowlist dictionary so the CLI (and any
+        // integration) can resolve it, regardless of Acorn vs standalone config.
+        if ($this->fastlyAllowlistDictionary !== null) {
+            add_filter('cachetags/fastly-allowlist-dictionary', fn () => $this->fastlyAllowlistDictionary);
+        }
 
         // Register WP-CLI commands if available
         $this->registerWpCliCommands();
@@ -219,6 +237,7 @@ class Bootstrap
         \WP_CLI::add_command('cachetags clear', WpCli\ClearCommand::class);
         \WP_CLI::add_command('cachetags status', WpCli\StatusCommand::class);
         \WP_CLI::add_command('cachetags prune', WpCli\PruneCommand::class);
+        \WP_CLI::add_command('cachetags fastly-allowlist', WpCli\FastlyAllowlistCommand::class);
     }
 
     protected function bindActions(): void

--- a/src/CacheTagsServiceProvider.php
+++ b/src/CacheTagsServiceProvider.php
@@ -4,6 +4,7 @@ namespace Genero\Sage\CacheTags;
 
 use Genero\Sage\CacheTags\Console\ClearCommand;
 use Genero\Sage\CacheTags\Console\DatabaseCommand;
+use Genero\Sage\CacheTags\Console\FastlyAllowlistCommand;
 use Genero\Sage\CacheTags\Console\FlushCommand;
 use Genero\Sage\CacheTags\Console\PruneCommand;
 use Genero\Sage\CacheTags\Console\StatusCommand;
@@ -36,6 +37,7 @@ class CacheTagsServiceProvider extends ServiceProvider
             ClearCommand::class,
             StatusCommand::class,
             PruneCommand::class,
+            FastlyAllowlistCommand::class,
         ]);
     }
 
@@ -53,6 +55,7 @@ class CacheTagsServiceProvider extends ServiceProvider
             autoDetectActions: $config->get('cachetags.auto-detect-actions', true),
             baseTag: $config->get('cachetags.base-tag', 'page'),
             pruneOlderThan: $config->get('cachetags.prune-older-than', '30d'),
+            fastlyAllowlistDictionary: $config->get('cachetags.fastly-allowlist-dictionary', null),
         );
 
         return $bootstrap;

--- a/src/Console/FastlyAllowlistCommand.php
+++ b/src/Console/FastlyAllowlistCommand.php
@@ -66,6 +66,16 @@ class FastlyAllowlistCommand extends Command
         }
 
         if ($action === 'sync') {
+            if ($dictionary->exceedsLimit($params)) {
+                $this->error(sprintf(
+                    'Allowlist too long (%d chars > %d) — too many attributes/facets for one dictionary item.',
+                    strlen(implode(',', $params)),
+                    AllowlistDictionary::MAX_VALUE_LENGTH
+                ));
+
+                return self::FAILURE;
+            }
+
             if (! $this->option('force') && $dictionary->isSynced($params)) {
                 $this->info('Already in sync; nothing to push.');
 

--- a/src/Console/FastlyAllowlistCommand.php
+++ b/src/Console/FastlyAllowlistCommand.php
@@ -54,7 +54,7 @@ class FastlyAllowlistCommand extends Command
             $this->line('Computed : '.implode(',', $params));
 
             if ($current === null) {
-                $this->warn('Dictionary item unavailable — check the dictionary exists and the token has write_dictionaries scope.');
+                $this->warn('No allowlist at Fastly yet — run sync. (If you have: check the dictionary exists and the token has write_dictionaries scope.)');
 
                 return self::SUCCESS;
             }

--- a/src/Console/FastlyAllowlistCommand.php
+++ b/src/Console/FastlyAllowlistCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Console;
+
+use Genero\Sage\CacheTags\Fastly\AllowlistDictionary;
+use Genero\Sage\CacheTags\Fastly\QueryAllowlist;
+use Roots\Acorn\Console\Commands\Command;
+
+class FastlyAllowlistCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $name = 'cachetags:fastly-allowlist';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Inspect and manage the Fastly query-param allowlist';
+
+    protected $signature = 'cachetags:fastly-allowlist
+        {action=preview : preview | status | sync}
+        {--dictionary= : Override the configured Edge Dictionary name}
+        {--force : Push even when the dictionary already matches}';
+
+    public function handle(): int
+    {
+        $params = QueryAllowlist::collect();
+        $action = (string) $this->argument('action');
+
+        if ($action === 'preview') {
+            $this->line(implode(PHP_EOL, $params));
+            $this->info(sprintf('%d cache-significant params. Add more via the cachetags/fastly-allowed-query-params filter, then sync.', count($params)));
+
+            return self::SUCCESS;
+        }
+
+        $name = $this->option('dictionary') ?: config('cachetags.fastly-allowlist-dictionary');
+        if (! $name) {
+            $this->error('No dictionary configured (cachetags.fastly-allowlist-dictionary) — or pass --dictionary.');
+
+            return self::FAILURE;
+        }
+
+        $dictionary = new AllowlistDictionary($name);
+        if (! $dictionary->isConfigured()) {
+            $this->error('FASTLY_SERVICE_ID / FASTLY_API_KEY are not set.');
+
+            return self::FAILURE;
+        }
+
+        if ($action === 'status') {
+            $current = $dictionary->current();
+            $this->line('Computed : '.implode(',', $params));
+            $this->line('At Fastly: '.($current ?? '(unset / unavailable)'));
+            $this->line($dictionary->isSynced($params) ? 'In sync.' : 'OUT OF SYNC — run sync.');
+
+            return self::SUCCESS;
+        }
+
+        if ($action === 'sync') {
+            if (! $this->option('force') && $dictionary->isSynced($params)) {
+                $this->info('Already in sync; nothing to push.');
+
+                return self::SUCCESS;
+            }
+
+            if ($dictionary->push($params)) {
+                $this->info(sprintf('Synced %d params to Fastly.', count($params)));
+
+                return self::SUCCESS;
+            }
+
+            $this->error('Push failed — check FASTLY_SERVICE_ID / FASTLY_API_KEY and the dictionary name.');
+
+            return self::FAILURE;
+        }
+
+        $this->error("Unknown action '{$action}'; use preview, status or sync.");
+
+        return self::FAILURE;
+    }
+}

--- a/src/Console/FastlyAllowlistCommand.php
+++ b/src/Console/FastlyAllowlistCommand.php
@@ -52,8 +52,15 @@ class FastlyAllowlistCommand extends Command
         if ($action === 'status') {
             $current = $dictionary->current();
             $this->line('Computed : '.implode(',', $params));
-            $this->line('At Fastly: '.($current ?? '(unset / unavailable)'));
-            $this->line($dictionary->isSynced($params) ? 'In sync.' : 'OUT OF SYNC — run sync.');
+
+            if ($current === null) {
+                $this->warn('Dictionary item unavailable — check the dictionary exists and the token has write_dictionaries scope.');
+
+                return self::SUCCESS;
+            }
+
+            $this->line('At Fastly: '.$current);
+            $this->line($current === implode(',', $params) ? 'In sync.' : 'OUT OF SYNC — run sync.');
 
             return self::SUCCESS;
         }

--- a/src/Fastly/AllowlistDictionary.php
+++ b/src/Fastly/AllowlistDictionary.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Fastly;
+
+use Genero\Sage\CacheTags\Util;
+
+/**
+ * Syncs the query-param allowlist (see QueryAllowlist) into a Fastly Edge
+ * Dictionary as a single comma-separated item, which a static VCL snippet reads
+ * to filter the cache key. Dictionary items are versionless — updates hit the
+ * live edge in ~30s with no service deploy.
+ *
+ * Stored as one item (key `params`) holding the comma-joined list; the value cap
+ * is 8000 chars, ample for hundreds of params. Reuses the FASTLY_SERVICE_ID /
+ * FASTLY_API_KEY env the purge invalidator uses.
+ */
+class AllowlistDictionary
+{
+    const BASE_URL = 'https://api.fastly.com';
+
+    const ITEM_KEY = 'params';
+
+    protected ?string $dictionaryId = null;
+
+    public function __construct(protected string $dictionary) {}
+
+    public function isConfigured(): bool
+    {
+        return (bool) Util::env('FASTLY_SERVICE_ID') && (bool) Util::env('FASTLY_API_KEY');
+    }
+
+    /**
+     * The allowlist value currently stored at Fastly (comma-separated), or null
+     * when the item, dictionary, or service is unavailable.
+     */
+    public function current(): ?string
+    {
+        $id = $this->dictionaryId();
+        if ($id === null) {
+            return null;
+        }
+
+        $item = $this->apiGet("/service/{$this->serviceId()}/dictionary/{$id}/item/".self::ITEM_KEY);
+
+        return isset($item['item_value']) ? (string) $item['item_value'] : null;
+    }
+
+    /**
+     * True when the dictionary already holds exactly this list (skip the push).
+     *
+     * @param  string[]  $params
+     */
+    public function isSynced(array $params): bool
+    {
+        return $this->current() === implode(',', $params);
+    }
+
+    /**
+     * Upsert the allowlist into the dictionary. One bulk PATCH = one API write.
+     *
+     * @param  string[]  $params
+     */
+    public function push(array $params): bool
+    {
+        $id = $this->dictionaryId();
+        if ($id === null) {
+            return false;
+        }
+
+        return $this->apiPatch("/service/{$this->serviceId()}/dictionary/{$id}/items", [
+            'items' => [[
+                'op' => 'upsert',
+                'item_key' => self::ITEM_KEY,
+                'item_value' => implode(',', $params),
+            ]],
+        ]);
+    }
+
+    /**
+     * Resolve the dictionary's id from its name on the active version (memoised
+     * for this request). Null when not configured or the dictionary is missing.
+     */
+    protected function dictionaryId(): ?string
+    {
+        if ($this->dictionaryId !== null) {
+            return $this->dictionaryId;
+        }
+        if (! $this->isConfigured()) {
+            return null;
+        }
+
+        $active = $this->apiGet("/service/{$this->serviceId()}/version/active");
+        $version = $active['number'] ?? null;
+        if ($version === null) {
+            return null;
+        }
+
+        $dictionary = $this->apiGet("/service/{$this->serviceId()}/version/{$version}/dictionary/{$this->dictionary}");
+
+        return $this->dictionaryId = isset($dictionary['id']) ? (string) $dictionary['id'] : null;
+    }
+
+    protected function serviceId(): string
+    {
+        return (string) Util::env('FASTLY_SERVICE_ID');
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function apiGet(string $path): ?array
+    {
+        $response = wp_remote_get(self::BASE_URL.$path, [
+            'headers' => ['Fastly-Key' => Util::env('FASTLY_API_KEY'), 'Accept' => 'application/json'],
+            'timeout' => 5,
+        ]);
+
+        if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+            return null;
+        }
+
+        $decoded = json_decode(wp_remote_retrieve_body($response), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $body
+     */
+    protected function apiPatch(string $path, array $body): bool
+    {
+        $response = wp_remote_request(self::BASE_URL.$path, [
+            'method' => 'PATCH',
+            'headers' => [
+                'Fastly-Key' => Util::env('FASTLY_API_KEY'),
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+            'body' => wp_json_encode($body),
+            'timeout' => 5,
+        ]);
+
+        return ! is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200;
+    }
+}

--- a/src/Fastly/AllowlistDictionary.php
+++ b/src/Fastly/AllowlistDictionary.php
@@ -10,9 +10,10 @@ use Genero\Sage\CacheTags\Util;
  * to filter the cache key. Dictionary items are versionless — updates hit the
  * live edge in ~30s with no service deploy.
  *
- * Stored as one item (key `params`) holding the comma-joined list; the value cap
- * is 8000 chars, ample for hundreds of params. Reuses the FASTLY_SERVICE_ID /
- * FASTLY_API_KEY env the purge invalidator uses.
+ * Stored as one item per host (key = the site host — see itemKey()) holding the
+ * comma-joined list, so a multisite network sharing one service doesn't clobber a
+ * single item; the value cap is 8000 chars, ample for hundreds of params. Reuses
+ * the FASTLY_SERVICE_ID / FASTLY_API_KEY env the purge invalidator uses.
  */
 class AllowlistDictionary
 {

--- a/src/Fastly/AllowlistDictionary.php
+++ b/src/Fastly/AllowlistDictionary.php
@@ -95,7 +95,8 @@ class AllowlistDictionary
             return null;
         }
 
-        $dictionary = $this->apiGet("/service/{$this->serviceId()}/version/{$version}/dictionary/{$this->dictionary}");
+        $name = rawurlencode($this->dictionary);
+        $dictionary = $this->apiGet("/service/{$this->serviceId()}/version/{$version}/dictionary/{$name}");
 
         return $this->dictionaryId = isset($dictionary['id']) ? (string) $dictionary['id'] : null;
     }

--- a/src/Fastly/AllowlistDictionary.php
+++ b/src/Fastly/AllowlistDictionary.php
@@ -18,11 +18,33 @@ class AllowlistDictionary
 {
     const BASE_URL = 'https://api.fastly.com';
 
-    const ITEM_KEY = 'params';
+    /** Fastly Edge Dictionary value cap. */
+    const MAX_VALUE_LENGTH = 8000;
 
     protected ?string $dictionaryId = null;
 
     public function __construct(protected string $dictionary) {}
+
+    /**
+     * Dictionary item key — the site's host, so a multisite network sharing one
+     * Fastly service stores one allowlist per host instead of clobbering a single
+     * shared item. The VCL looks the value up by `req.http.host`.
+     */
+    public function itemKey(): string
+    {
+        return (string) (parse_url(home_url(), PHP_URL_HOST) ?: 'params');
+    }
+
+    /**
+     * True when the comma-joined list would exceed the dictionary value cap — too
+     * many attributes/facets for one item. The caller should report it, not push.
+     *
+     * @param  string[]  $params
+     */
+    public function exceedsLimit(array $params): bool
+    {
+        return strlen(implode(',', $params)) > self::MAX_VALUE_LENGTH;
+    }
 
     public function isConfigured(): bool
     {
@@ -40,7 +62,7 @@ class AllowlistDictionary
             return null;
         }
 
-        $item = $this->apiGet("/service/{$this->serviceId()}/dictionary/{$id}/item/".self::ITEM_KEY);
+        $item = $this->apiGet("/service/{$this->serviceId()}/dictionary/{$id}/item/".rawurlencode($this->itemKey()));
 
         return isset($item['item_value']) ? (string) $item['item_value'] : null;
     }
@@ -63,14 +85,14 @@ class AllowlistDictionary
     public function push(array $params): bool
     {
         $id = $this->dictionaryId();
-        if ($id === null) {
+        if ($id === null || $this->exceedsLimit($params)) {
             return false;
         }
 
         return $this->apiPatch("/service/{$this->serviceId()}/dictionary/{$id}/items", [
             'items' => [[
                 'op' => 'upsert',
-                'item_key' => self::ITEM_KEY,
+                'item_key' => $this->itemKey(),
                 'item_value' => implode(',', $params),
             ]],
         ]);

--- a/src/Fastly/QueryAllowlist.php
+++ b/src/Fastly/QueryAllowlist.php
@@ -27,9 +27,7 @@ class QueryAllowlist
      */
     public static function collect(): array
     {
-        $params = ['s', 'post_type', 'orderby', 'order', 'paged', 'page'];
-
-        $params = array_merge($params, self::wooCommerce(), self::facetwp(), self::polylang());
+        $params = array_merge(self::core(), self::wooCommerce(), self::facetwp(), self::polylang());
 
         /**
          * Final say over the allowlist — add a site's bespoke params, or remove
@@ -58,6 +56,25 @@ class QueryAllowlist
      *
      * @return string[]
      */
+    /**
+     * WordPress's content-determining query vars — the built-ins plus anything a
+     * theme/plugin registers via the `query_vars` filter, so custom routable params
+     * aren't silently stripped. These all select content, so allowlisting them is
+     * safe; high-cardinality noise (trackers) is never a registered query var.
+     *
+     * @return string[]
+     */
+    protected static function core(): array
+    {
+        $builtins = [
+            's', 'post_type', 'orderby', 'order', 'paged', 'page', 'cpage',
+            'p', 'page_id', 'name', 'pagename', 'cat', 'category_name', 'tag',
+            'author', 'author_name', 'feed', 'm', 'year', 'monthnum', 'day',
+        ];
+
+        return array_map('strval', (array) apply_filters('query_vars', $builtins));
+    }
+
     protected static function wooCommerce(): array
     {
         return function_exists('wc_get_attribute_taxonomies')

--- a/src/Fastly/QueryAllowlist.php
+++ b/src/Fastly/QueryAllowlist.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Genero\Sage\CacheTags\Fastly;
+
+/**
+ * Computes the set of query-string parameter names that are *cache-significant*
+ * for this site — the ones an edge must keep in the cache key. Everything else
+ * (utm_*, gclid, fbclid, random bot/session junk) can be stripped at the edge so
+ * variants collapse to one cached object.
+ *
+ * This is the dynamic half of the edge query-param normalisation: WordPress knows
+ * which params matter (WooCommerce attributes, FacetWP facets, search), the edge
+ * doesn't. The list is pushed to a Fastly Edge Dictionary and a static VCL snippet
+ * filters the query string by it — see AllowlistDictionary and the README.
+ *
+ * Best-effort: the built-ins below cover the common cases, but a site MUST review
+ * the result (`wp cachetags fastly-allowlist preview`) and add anything missing
+ * via the `cachetags/fastly-allowed-query-params` filter. An incomplete list
+ * silently collapses real variants into one cached page — fail-dangerous.
+ */
+class QueryAllowlist
+{
+    const FILTER = 'cachetags/fastly-allowed-query-params';
+
+    /**
+     * @return string[] sorted, de-duplicated param names
+     */
+    public static function collect(): array
+    {
+        $params = ['s', 'orderby', 'order', 'paged', 'page'];
+
+        $params = array_merge($params, self::wooCommerce(), self::facetwp());
+
+        /**
+         * Final say over the allowlist — add a site's bespoke params, or remove
+         * one the built-ins got wrong. Receives and returns string[].
+         */
+        $params = (array) apply_filters(self::FILTER, $params);
+
+        $params = array_values(array_unique(array_filter(array_map('strval', $params))));
+        sort($params);
+
+        return $params;
+    }
+
+    /**
+     * WooCommerce archive/shop filtering params, including the layered-nav widget
+     * params for each registered product attribute (`filter_{slug}` +
+     * `query_type_{slug}`).
+     *
+     * @return string[]
+     */
+    protected static function wooCommerce(): array
+    {
+        if (! function_exists('wc_get_attribute_taxonomies')) {
+            return [];
+        }
+
+        $params = ['min_price', 'max_price', 'rating_filter', 'product_cat', 'product_tag'];
+
+        foreach (wc_get_attribute_taxonomies() as $attribute) {
+            $slug = $attribute->attribute_name;
+            $params[] = "filter_{$slug}";
+            $params[] = "query_type_{$slug}";
+        }
+
+        return $params;
+    }
+
+    /**
+     * FacetWP facet query vars (each facet reads `?{name}=…`).
+     *
+     * @return string[]
+     */
+    protected static function facetwp(): array
+    {
+        if (! function_exists('FWP') || ! is_object(FWP()->helper ?? null)) {
+            return [];
+        }
+
+        return array_map(
+            fn ($facet) => (string) ($facet['name'] ?? ''),
+            (array) FWP()->helper->get_facets()
+        );
+    }
+}

--- a/src/Fastly/QueryAllowlist.php
+++ b/src/Fastly/QueryAllowlist.php
@@ -20,7 +20,11 @@ namespace Genero\Sage\CacheTags\Fastly;
  */
 class QueryAllowlist
 {
+    /** Add/remove cache-significant params the built-ins didn't catch. */
     const FILTER = 'cachetags/fastly-allowed-query-params';
+
+    /** Last word over the exact list synced to Fastly (edit/add/remove). */
+    const SYNC_FILTER = 'cachetags/fastly-allowlist';
 
     /**
      * @return string[] sorted, de-duplicated param names
@@ -29,15 +33,27 @@ class QueryAllowlist
     {
         $params = array_merge(self::core(), self::wooCommerce(), self::facetwp(), self::polylang());
 
-        /**
-         * Final say over the allowlist — add a site's bespoke params, or remove
-         * one the built-ins got wrong. Receives and returns string[].
-         */
+        // Add a site's bespoke params, or drop one the built-ins got wrong.
         $params = (array) apply_filters(self::FILTER, $params);
 
-        // Reject names that aren't header/cache-key safe: a comma would corrupt the
-        // comma-joined dictionary value (and the VCL's filtersep split), whitespace
-        // or control chars would break the edge filter. Mirrors Util::isValidTag.
+        $params = self::sanitize($params);
+
+        // Last word over the exact list about to be synced — re-sanitised so an
+        // edit can't push a name that would corrupt the dictionary value.
+        return self::sanitize((array) apply_filters(self::SYNC_FILTER, $params));
+    }
+
+    /**
+     * Drop names that aren't header/cache-key safe (a comma would corrupt the
+     * comma-joined dictionary value and the VCL's filtersep split, whitespace or
+     * control chars would break the filter), then de-dupe and sort. Mirrors the
+     * discipline of Util::isValidTag.
+     *
+     * @param  mixed[]  $params
+     * @return string[]
+     */
+    protected static function sanitize(array $params): array
+    {
         $params = array_filter(
             array_map('strval', $params),
             fn ($param) => (bool) preg_match('/^[A-Za-z0-9_\-]+$/', $param)
@@ -49,13 +65,6 @@ class QueryAllowlist
         return $params;
     }
 
-    /**
-     * WooCommerce archive/shop filtering params, including the layered-nav widget
-     * params for each registered product attribute (`filter_{slug}` +
-     * `query_type_{slug}`).
-     *
-     * @return string[]
-     */
     /**
      * WordPress's content-determining query vars — the built-ins plus anything a
      * theme/plugin registers via the `query_vars` filter, so custom routable params

--- a/src/Fastly/QueryAllowlist.php
+++ b/src/Fastly/QueryAllowlist.php
@@ -27,9 +27,9 @@ class QueryAllowlist
      */
     public static function collect(): array
     {
-        $params = ['s', 'orderby', 'order', 'paged', 'page'];
+        $params = ['s', 'post_type', 'orderby', 'order', 'paged', 'page'];
 
-        $params = array_merge($params, self::wooCommerce(), self::facetwp());
+        $params = array_merge($params, self::wooCommerce(), self::facetwp(), self::polylang());
 
         /**
          * Final say over the allowlist — add a site's bespoke params, or remove
@@ -37,7 +37,15 @@ class QueryAllowlist
          */
         $params = (array) apply_filters(self::FILTER, $params);
 
-        $params = array_values(array_unique(array_filter(array_map('strval', $params))));
+        // Reject names that aren't header/cache-key safe: a comma would corrupt the
+        // comma-joined dictionary value (and the VCL's filtersep split), whitespace
+        // or control chars would break the edge filter. Mirrors Util::isValidTag.
+        $params = array_filter(
+            array_map('strval', $params),
+            fn ($param) => (bool) preg_match('/^[A-Za-z0-9_\-]+$/', $param)
+        );
+
+        $params = array_values(array_unique($params));
         sort($params);
 
         return $params;
@@ -52,13 +60,31 @@ class QueryAllowlist
      */
     protected static function wooCommerce(): array
     {
-        if (! function_exists('wc_get_attribute_taxonomies')) {
-            return [];
-        }
+        return function_exists('wc_get_attribute_taxonomies')
+            ? self::wooCommerceParams(wc_get_attribute_taxonomies())
+            : [];
+    }
 
-        $params = ['min_price', 'max_price', 'rating_filter', 'product_cat', 'product_tag'];
+    /**
+     * WooCommerce archive params for the given attribute taxonomies. Pure (no WC
+     * calls) so it's testable without WooCommerce loaded.
+     *
+     * @param  object[]  $taxonomies  objects with an `attribute_name` (un-prefixed slug)
+     * @return string[]
+     */
+    public static function wooCommerceParams(array $taxonomies): array
+    {
+        // post_type keeps product search (?s=…&post_type=product) distinct from
+        // blog search; product-page is the products-block pager.
+        $params = [
+            'post_type', 'product-page',
+            'min_price', 'max_price', 'rating_filter', 'filter_stock_status',
+            'product_cat', 'product_tag',
+        ];
 
-        foreach (wc_get_attribute_taxonomies() as $attribute) {
+        foreach ($taxonomies as $attribute) {
+            // Layered-nav / attribute-filter block read `filter_{slug}` +
+            // `query_type_{slug}`, where slug is the un-prefixed attribute name.
             $slug = $attribute->attribute_name;
             $params[] = "filter_{$slug}";
             $params[] = "query_type_{$slug}";
@@ -67,20 +93,43 @@ class QueryAllowlist
         return $params;
     }
 
-    /**
-     * FacetWP facet query vars (each facet reads `?{name}=…`).
-     *
-     * @return string[]
-     */
     protected static function facetwp(): array
     {
         if (! function_exists('FWP') || ! is_object(FWP()->helper ?? null)) {
             return [];
         }
 
-        return array_map(
-            fn ($facet) => (string) ($facet['name'] ?? ''),
-            (array) FWP()->helper->get_facets()
-        );
+        return self::facetParams((array) FWP()->helper->get_facets());
+    }
+
+    /**
+     * FacetWP query vars for the given facets. FacetWP prefixes every URL var with
+     * `_` (a facet named "color" reads `?_color=…`), plus its own pager/sort vars.
+     * Pure so it's testable without FacetWP loaded.
+     *
+     * @param  array<array{name?: string}>  $facets
+     * @return string[]
+     */
+    public static function facetParams(array $facets): array
+    {
+        $params = ['_paged', '_per_page', '_sort'];
+
+        foreach ($facets as $facet) {
+            if (! empty($facet['name'])) {
+                $params[] = '_'.$facet['name'];
+            }
+        }
+
+        return $params;
+    }
+
+    /**
+     * Polylang in query-string language mode keys on `?lang=…`.
+     *
+     * @return string[]
+     */
+    protected static function polylang(): array
+    {
+        return defined('POLYLANG_VERSION') ? ['lang'] : [];
     }
 }

--- a/src/WpCli/FastlyAllowlistCommand.php
+++ b/src/WpCli/FastlyAllowlistCommand.php
@@ -53,7 +53,7 @@ class FastlyAllowlistCommand extends WP_CLI_Command
         WP_CLI::log('Computed : '.implode(',', $params));
 
         if ($current === null) {
-            WP_CLI::warning('Dictionary item unavailable — check the dictionary exists and the token has write_dictionaries scope.');
+            WP_CLI::warning('No allowlist at Fastly yet — run `sync`. (If you have: check the dictionary exists and the token has write_dictionaries scope.)');
 
             return;
         }

--- a/src/WpCli/FastlyAllowlistCommand.php
+++ b/src/WpCli/FastlyAllowlistCommand.php
@@ -51,8 +51,15 @@ class FastlyAllowlistCommand extends WP_CLI_Command
         $current = $dictionary->current();
 
         WP_CLI::log('Computed : '.implode(',', $params));
-        WP_CLI::log('At Fastly: '.($current ?? '(unset / unavailable)'));
-        WP_CLI::log($dictionary->isSynced($params) ? 'In sync.' : 'OUT OF SYNC — run `sync`.');
+
+        if ($current === null) {
+            WP_CLI::warning('Dictionary item unavailable — check the dictionary exists and the token has write_dictionaries scope.');
+
+            return;
+        }
+
+        WP_CLI::log('At Fastly: '.$current);
+        WP_CLI::log($current === implode(',', $params) ? 'In sync.' : 'OUT OF SYNC — run `sync`.');
     }
 
     /**
@@ -94,6 +101,8 @@ class FastlyAllowlistCommand extends WP_CLI_Command
      */
     private function dictionary($assoc): AllowlistDictionary
     {
+        // Standalone WP-CLI has no Acorn config(); Bootstrap publishes the
+        // configured name through this filter so both contexts resolve it.
         $name = $assoc['dictionary'] ?? apply_filters('cachetags/fastly-allowlist-dictionary', null);
         if (! $name) {
             WP_CLI::error('No dictionary configured. Set "fastly-allowlist-dictionary" or pass --dictionary=<name>.');

--- a/src/WpCli/FastlyAllowlistCommand.php
+++ b/src/WpCli/FastlyAllowlistCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Genero\Sage\CacheTags\WpCli;
+
+use Genero\Sage\CacheTags\Fastly\AllowlistDictionary;
+use Genero\Sage\CacheTags\Fastly\QueryAllowlist;
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Inspect and manage the Fastly query-param allowlist (edge cache-key
+ * normalisation). See the README "Fastly query-param allowlist" section.
+ */
+class FastlyAllowlistCommand extends WP_CLI_Command
+{
+    /**
+     * Print the query-param allowlist WordPress computes — review it before sync.
+     *
+     * ## EXAMPLES
+     *
+     *     $ wp cachetags fastly-allowlist preview
+     *
+     * @param  string[]  $args
+     * @param  array<string, string>  $assoc
+     */
+    public function preview($args, $assoc): void
+    {
+        $params = QueryAllowlist::collect();
+
+        WP_CLI::log(implode(PHP_EOL, $params));
+        WP_CLI::log('');
+        WP_CLI::log(sprintf('%d cache-significant params. Anything else is stripped at the edge.', count($params)));
+        WP_CLI::log('Add missing params via the cachetags/fastly-allowed-query-params filter, then `sync`.');
+    }
+
+    /**
+     * Show the dictionary's current value at Fastly and whether it's in sync.
+     *
+     * ## OPTIONS
+     *
+     * [--dictionary=<name>]
+     * : Override the configured Edge Dictionary name.
+     *
+     * @param  string[]  $args
+     * @param  array<string, string>  $assoc
+     */
+    public function status($args, $assoc): void
+    {
+        $dictionary = $this->dictionary($assoc);
+        $params = QueryAllowlist::collect();
+        $current = $dictionary->current();
+
+        WP_CLI::log('Computed : '.implode(',', $params));
+        WP_CLI::log('At Fastly: '.($current ?? '(unset / unavailable)'));
+        WP_CLI::log($dictionary->isSynced($params) ? 'In sync.' : 'OUT OF SYNC — run `sync`.');
+    }
+
+    /**
+     * Push the computed allowlist to the Fastly Edge Dictionary.
+     *
+     * ## OPTIONS
+     *
+     * [--dictionary=<name>]
+     * : Override the configured Edge Dictionary name.
+     *
+     * [--force]
+     * : Push even when the dictionary already matches.
+     *
+     * ## EXAMPLES
+     *
+     *     $ wp cachetags fastly-allowlist sync
+     *
+     * @param  string[]  $args
+     * @param  array<string, string>  $assoc
+     */
+    public function sync($args, $assoc): void
+    {
+        $dictionary = $this->dictionary($assoc);
+        $params = QueryAllowlist::collect();
+
+        if (! isset($assoc['force']) && $dictionary->isSynced($params)) {
+            WP_CLI::success('Already in sync; nothing to push.');
+
+            return;
+        }
+
+        $dictionary->push($params)
+            ? WP_CLI::success(sprintf('Synced %d params to Fastly.', count($params)))
+            : WP_CLI::error('Push failed — check FASTLY_SERVICE_ID / FASTLY_API_KEY and the dictionary name.');
+    }
+
+    /**
+     * @param  array<string, string>  $assoc
+     */
+    private function dictionary($assoc): AllowlistDictionary
+    {
+        $name = $assoc['dictionary'] ?? apply_filters('cachetags/fastly-allowlist-dictionary', null);
+        if (! $name) {
+            WP_CLI::error('No dictionary configured. Set "fastly-allowlist-dictionary" or pass --dictionary=<name>.');
+        }
+
+        $dictionary = new AllowlistDictionary($name);
+        if (! $dictionary->isConfigured()) {
+            WP_CLI::error('FASTLY_SERVICE_ID / FASTLY_API_KEY are not set.');
+        }
+
+        return $dictionary;
+    }
+}

--- a/src/WpCli/FastlyAllowlistCommand.php
+++ b/src/WpCli/FastlyAllowlistCommand.php
@@ -85,6 +85,14 @@ class FastlyAllowlistCommand extends WP_CLI_Command
         $dictionary = $this->dictionary($assoc);
         $params = QueryAllowlist::collect();
 
+        if ($dictionary->exceedsLimit($params)) {
+            WP_CLI::error(sprintf(
+                'Allowlist too long (%d chars > %d) — too many attributes/facets for one dictionary item.',
+                strlen(implode(',', $params)),
+                AllowlistDictionary::MAX_VALUE_LENGTH
+            ));
+        }
+
         if (! isset($assoc['force']) && $dictionary->isSynced($params)) {
             WP_CLI::success('Already in sync; nothing to push.');
 

--- a/tests/integration/test-bootstrap.php
+++ b/tests/integration/test-bootstrap.php
@@ -131,6 +131,15 @@ class TestBootstrap extends WP_UnitTestCase
         $this->assertFalse(wp_next_scheduled(PruneCron::HOOK), 'orphaned cron cleaned up');
     }
 
+    public function test_fastly_allowlist_dictionary_is_exposed_via_filter_when_configured(): void
+    {
+        (new Bootstrap)->store(TransientStore::class)->actions([])->disable()
+            ->fastlyAllowlistDictionary('shop_allowlist')->bootstrap();
+
+        $this->assertSame('shop_allowlist', apply_filters('cachetags/fastly-allowlist-dictionary', null));
+        remove_all_filters('cachetags/fastly-allowlist-dictionary');
+    }
+
     public function test_save_cache_tags_stores_a_cacheable_front_end_url(): void
     {
         $store = new TransientStore;

--- a/tests/integration/test-fastly-allowlist.php
+++ b/tests/integration/test-fastly-allowlist.php
@@ -1,0 +1,100 @@
+<?php
+
+use Genero\Sage\CacheTags\Fastly\AllowlistDictionary;
+use Genero\Sage\CacheTags\Fastly\QueryAllowlist;
+
+/**
+ * @covers \Genero\Sage\CacheTags\Fastly\QueryAllowlist
+ * @covers \Genero\Sage\CacheTags\Fastly\AllowlistDictionary
+ */
+class TestFastlyAllowlist extends WP_UnitTestCase
+{
+    public function test_collect_includes_core_params_sorted_and_unique(): void
+    {
+        $params = QueryAllowlist::collect();
+
+        foreach (['orderby', 'paged', 's'] as $param) {
+            $this->assertContains($param, $params);
+        }
+
+        $sorted = $params;
+        sort($sorted);
+        $this->assertSame($sorted, $params, 'sorted');
+        $this->assertSame(array_values(array_unique($params)), $params, 'de-duplicated');
+    }
+
+    public function test_filter_can_add_and_remove_params(): void
+    {
+        add_filter(QueryAllowlist::FILTER, fn ($params) => array_merge(array_diff($params, ['order']), ['my_facet', 'my_facet']));
+
+        $params = QueryAllowlist::collect();
+
+        $this->assertContains('my_facet', $params);
+        $this->assertNotContains('order', $params);
+        $this->assertSame(1, count(array_keys($params, 'my_facet', true)), 'still de-duplicated');
+    }
+
+    public function test_push_upserts_the_comma_joined_allowlist(): void
+    {
+        $dictionary = new class('mydict') extends AllowlistDictionary
+        {
+            /** @var array<string, mixed> */
+            public array $patched = [];
+
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+
+            protected function dictionaryId(): ?string
+            {
+                return 'abc123';
+            }
+
+            protected function apiPatch(string $path, array $body): bool
+            {
+                $this->patched = ['path' => $path, 'body' => $body];
+
+                return true;
+            }
+        };
+
+        $this->assertTrue($dictionary->push(['orderby', 'paged']));
+        $this->assertStringContainsString('/dictionary/abc123/items', $dictionary->patched['path']);
+
+        $item = $dictionary->patched['body']['items'][0];
+        $this->assertSame('upsert', $item['op']);
+        $this->assertSame('params', $item['item_key']);
+        $this->assertSame('orderby,paged', $item['item_value']);
+    }
+
+    public function test_is_synced_compares_current_value_to_the_joined_list(): void
+    {
+        $dictionary = new class('mydict') extends AllowlistDictionary
+        {
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+
+            protected function dictionaryId(): ?string
+            {
+                return 'abc';
+            }
+
+            protected function apiGet(string $path): ?array
+            {
+                return ['item_value' => 'orderby,paged'];
+            }
+        };
+
+        $this->assertTrue($dictionary->isSynced(['orderby', 'paged']));
+        $this->assertFalse($dictionary->isSynced(['orderby']));
+    }
+
+    public function test_push_fails_when_the_dictionary_cannot_be_resolved(): void
+    {
+        // Not configured (no FASTLY_* env) → dictionaryId() is null → no API call.
+        $this->assertFalse((new AllowlistDictionary('missing'))->push(['orderby']));
+    }
+}

--- a/tests/integration/test-fastly-allowlist.php
+++ b/tests/integration/test-fastly-allowlist.php
@@ -110,8 +110,27 @@ class TestFastlyAllowlist extends WP_UnitTestCase
 
         $item = $dictionary->patched['body']['items'][0];
         $this->assertSame('upsert', $item['op']);
-        $this->assertSame('params', $item['item_key']);
+        $this->assertSame(parse_url(home_url(), PHP_URL_HOST), $item['item_key'], 'keyed per host');
         $this->assertSame('orderby,paged', $item['item_value']);
+    }
+
+    public function test_exceeds_limit_guards_the_8000_char_value_cap(): void
+    {
+        $dictionary = new AllowlistDictionary('d');
+
+        $this->assertFalse($dictionary->exceedsLimit(['orderby', 'paged']));
+        // ~9000 chars of comma-joined names.
+        $this->assertTrue($dictionary->exceedsLimit(array_map(fn ($i) => "param_{$i}", range(1, 1000))));
+    }
+
+    public function test_collect_includes_custom_registered_query_vars(): void
+    {
+        // A theme/plugin registering a public query var should be allowlisted, not
+        // silently stripped at the edge.
+        add_filter('query_vars', fn ($vars) => array_merge($vars, ['my_theme_filter']));
+
+        $this->assertContains('my_theme_filter', QueryAllowlist::collect());
+        $this->assertContains('cpage', QueryAllowlist::collect(), 'comment paging');
     }
 
     public function test_is_synced_compares_current_value_to_the_joined_list(): void

--- a/tests/integration/test-fastly-allowlist.php
+++ b/tests/integration/test-fastly-allowlist.php
@@ -50,6 +50,17 @@ class TestFastlyAllowlist extends WP_UnitTestCase
         }
     }
 
+    public function test_sync_filter_takes_the_last_word_and_is_resanitised(): void
+    {
+        add_filter('cachetags/fastly-allowlist', fn ($p) => array_merge(array_diff($p, ['s']), ['extra', 'bad,name']));
+
+        $params = QueryAllowlist::collect();
+
+        $this->assertContains('extra', $params, 'added via the sync filter');
+        $this->assertNotContains('s', $params, 'removed via the sync filter');
+        $this->assertNotContains('bad,name', $params, 're-sanitised — a comma cannot reach the dictionary');
+    }
+
     public function test_woocommerce_params_use_unprefixed_attribute_slug(): void
     {
         $params = QueryAllowlist::wooCommerceParams([

--- a/tests/integration/test-fastly-allowlist.php
+++ b/tests/integration/test-fastly-allowlist.php
@@ -34,6 +34,52 @@ class TestFastlyAllowlist extends WP_UnitTestCase
         $this->assertSame(1, count(array_keys($params, 'my_facet', true)), 'still de-duplicated');
     }
 
+    public function test_rejects_names_that_arent_cache_key_safe(): void
+    {
+        // A comma would split the dictionary value; whitespace/control breaks the
+        // VCL filter. Such names are dropped, valid ones kept.
+        add_filter(QueryAllowlist::FILTER, fn ($p) => array_merge($p, ['ok_name', 'has,comma', 'has space', "ctrl\n"]));
+
+        $params = QueryAllowlist::collect();
+
+        $this->assertContains('ok_name', $params);
+        $this->assertNotContains('has,comma', $params);
+        $this->assertNotContains('has space', $params);
+        foreach ($params as $param) {
+            $this->assertMatchesRegularExpression('/^[A-Za-z0-9_\-]+$/', $param);
+        }
+    }
+
+    public function test_woocommerce_params_use_unprefixed_attribute_slug(): void
+    {
+        $params = QueryAllowlist::wooCommerceParams([
+            (object) ['attribute_name' => 'color'],
+            (object) ['attribute_name' => 'size'],
+        ]);
+
+        $this->assertContains('filter_color', $params);
+        $this->assertContains('query_type_color', $params);
+        $this->assertContains('filter_size', $params);
+        $this->assertContains('post_type', $params, 'product search vs blog search');
+        $this->assertContains('filter_stock_status', $params);
+    }
+
+    public function test_facetwp_params_are_underscore_prefixed(): void
+    {
+        $params = QueryAllowlist::facetParams([
+            ['name' => 'flavors'],
+            ['name' => 'brand'],
+            ['label' => 'no name — skipped'],
+        ]);
+
+        // FacetWP reads ?_flavors=…, not ?flavors=… — the prefix is the whole point.
+        $this->assertContains('_flavors', $params);
+        $this->assertContains('_brand', $params);
+        $this->assertNotContains('flavors', $params);
+        $this->assertContains('_paged', $params);
+        $this->assertContains('_sort', $params);
+    }
+
     public function test_push_upserts_the_comma_joined_allowlist(): void
     {
         $dictionary = new class('mydict') extends AllowlistDictionary
@@ -90,6 +136,53 @@ class TestFastlyAllowlist extends WP_UnitTestCase
 
         $this->assertTrue($dictionary->isSynced(['orderby', 'paged']));
         $this->assertFalse($dictionary->isSynced(['orderby']));
+    }
+
+    public function test_resolves_dictionary_id_via_the_active_version(): void
+    {
+        $dictionary = new class('shop_allowlist') extends AllowlistDictionary
+        {
+            /** @var string[] */
+            public array $gets = [];
+
+            public string $patchedPath = '';
+
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+
+            protected function serviceId(): string
+            {
+                return 'svc1';
+            }
+
+            protected function apiGet(string $path): ?array
+            {
+                $this->gets[] = $path;
+
+                if (str_contains($path, '/version/active')) {
+                    return ['number' => 7];
+                }
+                if (str_contains($path, '/dictionary/shop_allowlist')) {
+                    return ['id' => 'dictABC'];
+                }
+
+                return null;
+            }
+
+            protected function apiPatch(string $path, array $body): bool
+            {
+                $this->patchedPath = $path;
+
+                return true;
+            }
+        };
+
+        $this->assertTrue($dictionary->push(['orderby']));
+        $this->assertContains('/service/svc1/version/active', $dictionary->gets);
+        $this->assertContains('/service/svc1/version/7/dictionary/shop_allowlist', $dictionary->gets);
+        $this->assertSame('/service/svc1/dictionary/dictABC/items', $dictionary->patchedPath);
     }
 
     public function test_push_fails_when_the_dictionary_cannot_be_resolved(): void


### PR DESCRIPTION
Towards #31. **325 tests green.** Opt-in, off by default.

Query-string variants fragment the edge cache (`/shop/?orderby=price&fbclid=x` vs `…?orderby=price` = two objects). The robust fix is an **allowlist** — only cache-significant params belong in the cache key — but that list is site-specific and dynamic, which only WordPress knows. #31 noted this belongs at the edge; this keeps the *enforcement* at the edge (static VCL) while the plugin owns the *dynamic allowlist* and syncs it.

## How it works
1. **`Fastly\QueryAllowlist::collect()`** computes the cache-significant params: core (`s`, `orderby`, `paged`), WooCommerce (per-attribute `filter_*`/`query_type_*`, price, rating), FacetWP facets, plus a `cachetags/fastly-allowed-query-params` filter.
2. **`Fastly\AllowlistDictionary`** syncs the list to a Fastly **Edge Dictionary** item — versionless, live in ~30s, no deploy. Resolves the dictionary id, change-detects, bulk-upserts (one API write), reuses `FASTLY_SERVICE_ID`/`FASTLY_API_KEY`.
3. A static **VCL snippet** reads the dictionary and filters the cache key (`table.lookup` → `regsuball` comma→`filtersep()` → `querystring.filter_except` → `querystring.sort`).

## CLI (inspect & manage)
```
wp cachetags fastly-allowlist preview   # the computed list — review before sync
wp cachetags fastly-allowlist sync      # push to the dictionary (change-detected; --force)
wp cachetags fastly-allowlist status    # dictionary value at Fastly + in-sync?
```
(WpCli + Acorn `Console` variants.)

## Opt in
`'fastly-allowlist-dictionary' => 'cachetags_query_allowlist'` (null = off). Bootstrap exposes the name via a resolution filter so the CLI resolves it on both Acorn and standalone.

## The risk, handled
An incomplete allowlist is **fail-dangerous** — a stripped-but-meaningful param silently collapses real variants → wrong content. Mitigations: VCL **fail-open** until first sync (`if (var.allow != "")`), `preview` for operator sign-off, the filter escape hatch, and a prominent README warning. KV Store was ruled out (Compute-only; unreadable from a VCL service) — Edge Dictionary is the fit.

Sync is **manual (CLI)** by design here; an auto-on-change/deploy-hook trigger is a deliberate follow-up so a potentially-incomplete list is never pushed silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)